### PR TITLE
Rewrite WHERE predicates separately by projection

### DIFF
--- a/translation/src/main/scala/org/opencypher/gremlin/translation/CypherAst.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/CypherAst.scala
@@ -25,7 +25,7 @@ import org.neo4j.cypher.internal.frontend.v3_3.phases._
 import org.opencypher.gremlin.translation.context.StatementContext
 import org.opencypher.gremlin.translation.ir.TranslationWriter
 import org.opencypher.gremlin.translation.ir.builder.{IRGremlinBindings, IRGremlinPredicates, IRGremlinSteps}
-import org.opencypher.gremlin.translation.ir.rewrite.PropertyMatchAdjacency
+import org.opencypher.gremlin.translation.ir.rewrite.FilterStepAdjacency
 import org.opencypher.gremlin.translation.preparser.{
   CypherPreParser,
   ExplainOption,
@@ -71,7 +71,7 @@ class CypherAst(val statement: Statement, val extractedParameters: Map[String, A
 
     TranslationWriter
       .from(ir)
-      .rewrite(PropertyMatchAdjacency)
+      .rewrite(FilterStepAdjacency)
       .translate(dsl)
   }
 

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/Rewriting.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/Rewriting.scala
@@ -26,6 +26,7 @@ object Rewriting {
 
   /**
     * Finds matching parts of an IR sequence and maps occurrences.
+    *
     * @param steps IR sequence
     * @param finder matching and mapping function
     * @tparam R mapping result
@@ -47,7 +48,8 @@ object Rewriting {
   }
 
   /**
-    * Finds matching parts of an IR sequence and replaces them
+    * Finds matching parts of an IR sequence and replaces them.
+    *
     * @param steps IR sequence
     * @param replacer matching and replacing function
     * @return rewritten IR sequence
@@ -70,5 +72,33 @@ object Rewriting {
       }
     }
     replaceAcc(Nil, steps)
+  }
+
+  /**
+    * Finds matching steps in the IR sequence and splits the sequence in segments,
+    * with each matching step marking the end of a segment.
+    *
+    * @param steps IR sequence
+    * @param splitter matching function
+    * @return IR sequence segments
+    */
+  def splitAfter(steps: Seq[GremlinStep], splitter: GremlinStep => Boolean): Seq[Seq[GremlinStep]] = {
+    @tailrec def splitAfterAcc(
+        acc: Seq[Seq[GremlinStep]],
+        current: Seq[GremlinStep],
+        rest: Seq[GremlinStep]): Seq[Seq[GremlinStep]] = {
+      rest match {
+        case step :: _ =>
+          val next = current :+ step
+          if (splitter(step)) {
+            splitAfterAcc(acc :+ next, Nil, rest.tail)
+          } else {
+            splitAfterAcc(acc, next, rest.tail)
+          }
+        case Nil =>
+          if (current.nonEmpty) acc :+ current else acc
+      }
+    }
+    splitAfterAcc(Nil, Nil, steps)
   }
 }

--- a/translation/src/test/java/org/opencypher/gremlin/translation/ir/rewrite/FilterStepAdjacencyTest.java
+++ b/translation/src/test/java/org/opencypher/gremlin/translation/ir/rewrite/FilterStepAdjacencyTest.java
@@ -24,7 +24,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.Scope;
 import org.junit.Test;
 import org.opencypher.gremlin.translation.Tokens;
 
-public class PropertyMatchAdjacencyTest {
+public class FilterStepAdjacencyTest {
 
     @Test
     public void singlePattern() {

--- a/translation/src/test/scala/org/opencypher/gremlin/translation/ir/rewrite/RewritingTest.scala
+++ b/translation/src/test/scala/org/opencypher/gremlin/translation/ir/rewrite/RewritingTest.scala
@@ -68,4 +68,20 @@ class RewritingTest {
     )
   }
 
+  @Test
+  def splitAfter(): Unit = {
+    val seq = Vertex :: As("n") :: OutE("rel") :: As("r") :: InV :: As("m") :: Nil
+    val segments = Rewriting.splitAfter(seq, {
+      case As(_) => true
+      case _     => false
+    })
+
+    assertThat(segments).isEqualTo(
+      Seq(
+        Vertex :: As("n") :: Nil,
+        OutE("rel") :: As("r") :: Nil,
+        InV :: As("m") :: Nil
+      ))
+  }
+
 }


### PR DESCRIPTION
WHERE predicate relocation should now also handle shadowed step labels.