### PR TITLE
Remove unused aliases

### DIFF
--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/CastTest.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/CastTest.java
@@ -37,10 +37,19 @@ public class CastTest {
 
     @Test
     public void castToString() throws Exception {
-        List<Map<String, Object>> results = submitAndGet(
-            "UNWIND [13, 3.14, 'Hello', true, null] AS n\n" +
-                "RETURN toString(n) AS r"
-        );
+        List<Map<String, Object>> results = Stream.of(
+            "13",
+            "3.14",
+            "'Hello'",
+            "true",
+            "null"
+        )
+            .flatMap(literal -> submitAndGet(
+                "WITH " + literal + " AS l " +
+                    "RETURN toString(l) AS r"
+            ).stream())
+            .collect(toList());
+
         assertThat(results)
             .extracting("r")
             .containsExactly(
@@ -54,10 +63,20 @@ public class CastTest {
 
     @Test
     public void castToInteger() throws Exception {
-        List<Map<String, Object>> results = submitAndGet(
-            "UNWIND [13, 3.14, '13', '3.14', 'Hello', null] AS n\n" +
-                "RETURN toInteger(n) AS r"
-        );
+        List<Map<String, Object>> results = Stream.of(
+            "13",
+            "3.14",
+            "'13'",
+            "'3.14'",
+            "'Hello'",
+            "null"
+        )
+            .flatMap(literal -> submitAndGet(
+                "WITH " + literal + " AS l " +
+                    "RETURN toInteger(l) AS r"
+            ).stream())
+            .collect(toList());
+
         assertThat(results)
             .extracting("r")
             .containsExactly(
@@ -91,10 +110,20 @@ public class CastTest {
 
     @Test
     public void castToFloat() throws Exception {
-        List<Map<String, Object>> results = submitAndGet(
-            "UNWIND [13, 3.14, '13', '3.14', 'Hello', null] AS n\n" +
-                "RETURN toFloat(n) AS r"
-        );
+        List<Map<String, Object>> results = Stream.of(
+            "13",
+            "3.14",
+            "'13'",
+            "'3.14'",
+            "'Hello'",
+            "null"
+        )
+            .flatMap(literal -> submitAndGet(
+                "WITH " + literal + " AS l " +
+                    "RETURN toFloat(l) AS r"
+            ).stream())
+            .collect(toList());
+
         assertThat(results)
             .extracting("r")
             .containsExactly(
@@ -128,10 +157,22 @@ public class CastTest {
 
     @Test
     public void castToBoolean() throws Exception {
-        List<Map<String, Object>> results = submitAndGet(
-            "UNWIND [true, false, 'True', 'False', '13', '3.14', 'Hello', null] AS n\n" +
-                "RETURN toBoolean(n) AS r"
-        );
+        List<Map<String, Object>> results = Stream.of(
+            "true",
+            "false",
+            "'True'",
+            "'False'",
+            "'13'",
+            "'3.14'",
+            "'Hello'",
+            "null"
+        )
+            .flatMap(literal -> submitAndGet(
+                "WITH " + literal + " AS l " +
+                    "RETURN toBoolean(l) AS r"
+            ).stream())
+            .collect(toList());
+
         assertThat(results)
             .extracting("r")
             .containsExactly(

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/GroupStepFilters.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/GroupStepFilters.scala
@@ -26,7 +26,7 @@ import scala.collection.mutable
   * This should allow Gremlin provider optimization strategies
   * to fold generated `has` steps into the adjacent vertex step.
   */
-object FilterStepAdjacency extends GremlinRewriter {
+object GroupStepFilters extends GremlinRewriter {
   override def apply(steps: Seq[GremlinStep]): Seq[GremlinStep] = {
     splitAfter({
       case MapT(Project(_*) :: _) => true

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/RemoveImmediateReselect.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/RemoveImmediateReselect.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2018 "Neo4j, Inc." [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opencypher.gremlin.translation.ir.rewrite
+
+import org.opencypher.gremlin.translation.ir.TraversalHelper._
+import org.opencypher.gremlin.translation.ir.model._
+
+/**
+  * This rewriter removes `select` steps that immediately follow an `as` step with the same label.
+  * Since the expected value is already in the tarverser, this is a useless operation.
+  * This rewrite also enables some cases of [[RemoveUnusedAliases]] rewrites.
+  */
+object RemoveImmediateReselect extends GremlinRewriter {
+  override def apply(steps: Seq[GremlinStep]): Seq[GremlinStep] = {
+    mapTraversals(replace({
+      case As(stepLabel) :: SelectK(selectKey) :: rest if stepLabel == selectKey =>
+        As(stepLabel) :: rest
+    }))(steps)
+  }
+}

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/RemoveUnusedAliases.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/RemoveUnusedAliases.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2018 "Neo4j, Inc." [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opencypher.gremlin.translation.ir.rewrite
+import org.opencypher.gremlin.translation.ir.TraversalHelper._
+import org.opencypher.gremlin.translation.ir.model._
+
+import scala.collection.SortedMap
+
+/**
+  * This rewriter removes many cases of `as` steps that have been generated,
+  * but are not actually used in the traversal.
+  * This enables some default Gremlin optimization strategies like
+  * [[org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.IncidentToAdjacentStrategy]]
+  * and allows bulking by keeping traversers compact.
+  */
+object RemoveUnusedAliases extends GremlinRewriter {
+  override def apply(steps: Seq[GremlinStep]): Seq[GremlinStep] = {
+    splitAfter({
+      case MapT(Project(_*) :: _) => true
+      case _                      => false
+    })(steps)
+      .flatMap(rewriteSegment)
+  }
+
+  private def rewriteSegment(steps: Seq[GremlinStep]): Seq[GremlinStep] = {
+    val selected = foldTraversals(SortedMap.empty[String, Int])((acc, localSteps) => {
+      def increment(keys: String*): SortedMap[String, Int] = {
+        keys.foldLeft(acc)((acc, key) => acc.updated(key, acc.getOrElse(key, 0) + 1))
+      }
+      acc ++ extract({
+        case From(fromStepLabel) :: _      => increment(fromStepLabel)
+        case To(toStepLabel) :: _          => increment(toStepLabel)
+        case SelectK(selectKeys @ _*) :: _ => increment(selectKeys: _*)
+        case WhereP(predicate) :: _        => increment(predicateAliases(predicate): _*)
+      })(localSteps).flatten
+    })(steps)
+
+    mapTraversals(
+      replace({
+        case before :: As(stepLabel) :: after if !selected.contains(stepLabel) =>
+          before :: after
+      })
+    )(steps)
+  }
+
+  def predicateAliases(predicate: GremlinPredicate): Seq[String] = {
+    def strings(values: Any*): Seq[String] = {
+      values
+        .filter(_.isInstanceOf[String])
+        .map(_.asInstanceOf[String])
+    }
+    predicate match {
+      case Eq(value)              => strings(value)
+      case Gt(value)              => strings(value)
+      case Gte(value)             => strings(value)
+      case Lt(value)              => strings(value)
+      case Lte(value)             => strings(value)
+      case Neq(value)             => strings(value)
+      case Between(first, second) => strings(first, second)
+      case Within(values @ _*)    => strings(values: _*)
+      case Without(values @ _*)   => strings(values: _*)
+      case StartsWith(value)      => strings(value)
+      case EndsWith(value)        => strings(value)
+      case Contains(value)        => strings(value)
+    }
+  }
+}

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/translator/TranslatorFlavor.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/translator/TranslatorFlavor.scala
@@ -15,8 +15,8 @@
  */
 package org.opencypher.gremlin.translation.translator
 
-import org.opencypher.gremlin.translation.ir.rewrite.{CosmosDbFlavor, FilterStepAdjacency, GremlinRewriter}
-import org.opencypher.gremlin.translation.ir.verify.{GremlinPostCondition, NoCustomFunctions}
+import org.opencypher.gremlin.translation.ir.rewrite._
+import org.opencypher.gremlin.translation.ir.verify._
 
 /**
   * A flavor defines translation rewriting rules and post-conditions.
@@ -38,7 +38,9 @@ object TranslatorFlavor {
     */
   val gremlinServer: TranslatorFlavor = TranslatorFlavor(
     rewriters = Seq(
-      FilterStepAdjacency
+      GroupStepFilters,
+      RemoveImmediateReselect,
+      RemoveUnusedAliases
     ),
     postConditions = Nil)
 

--- a/translation/src/test/java/org/opencypher/gremlin/translation/helpers/CypherAstAssert.java
+++ b/translation/src/test/java/org/opencypher/gremlin/translation/helpers/CypherAstAssert.java
@@ -20,6 +20,7 @@ import static java.util.function.Function.identity;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.assertj.core.api.AbstractAssert;
 import org.opencypher.gremlin.translation.CypherAstWrapper;
@@ -71,12 +72,19 @@ public class CypherAstAssert extends AbstractAssert<CypherAstAssert, CypherAstWr
             "group\\(\\)\\.by\\([^)]+\\)\\.by\\([^)]+\\)|" +
             "map\\(__\\.project|" +
             "fold\\(\\)\\.map\\(__\\.project" +
-            ").*$"
+            ")"
     );
 
     public CypherAstAssert hasTraversalBeforeReturn(GremlinSteps traversal) {
         // Extract everything up to the start of the RETURN clause translation
-        return hasTraversal(traversal, t -> RETURN_START.matcher(t).replaceFirst(""));
+        return hasTraversal(traversal, t -> {
+            Matcher matcher = RETURN_START.matcher(t);
+            int lastIndex = -1;
+            while (matcher.find()) {
+                lastIndex = matcher.start();
+            }
+            return t.substring(0, lastIndex);
+        });
     }
 
     private CypherAstAssert hasTraversal(GremlinSteps traversal,

--- a/translation/src/test/java/org/opencypher/gremlin/translation/ir/rewrite/GroupStepFiltersTest.java
+++ b/translation/src/test/java/org/opencypher/gremlin/translation/ir/rewrite/GroupStepFiltersTest.java
@@ -27,10 +27,10 @@ import org.junit.Test;
 import org.opencypher.gremlin.translation.Tokens;
 import org.opencypher.gremlin.translation.translator.TranslatorFlavor;
 
-public class FilterStepAdjacencyTest {
+public class GroupStepFiltersTest {
 
     private final TranslatorFlavor flavor = new TranslatorFlavor(
-        seq(FilterStepAdjacency$.MODULE$),
+        seq(GroupStepFilters$.MODULE$),
         seq()
     );
 

--- a/translation/src/test/java/org/opencypher/gremlin/translation/ir/rewrite/RemoveImmediateReselectTest.java
+++ b/translation/src/test/java/org/opencypher/gremlin/translation/ir/rewrite/RemoveImmediateReselectTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2018 "Neo4j, Inc." [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opencypher.gremlin.translation.ir.rewrite;
+
+import static org.opencypher.gremlin.translation.helpers.CypherAstAssertions.assertThat;
+import static org.opencypher.gremlin.translation.helpers.CypherAstHelpers.parse;
+import static org.opencypher.gremlin.translation.helpers.ScalaHelpers.seq;
+
+import org.junit.Test;
+import org.opencypher.gremlin.translation.helpers.CypherAstHelpers.__;
+import org.opencypher.gremlin.translation.translator.TranslatorFlavor;
+
+public class RemoveImmediateReselectTest {
+
+    private final TranslatorFlavor flavor = new TranslatorFlavor(
+        seq(RemoveImmediateReselect$.MODULE$),
+        seq()
+    );
+
+    @Test
+    public void aliasProjection() {
+        assertThat(parse(
+            "MATCH (n) " +
+                "WITH n AS m " +
+                "RETURN m"
+        ))
+            .withFlavor(flavor)
+            .hasTraversalBeforeReturn(
+                __.V()
+                    .as("n")
+                    .map(__.project("m").by(__.identity())).select("m")
+                    .as("m")
+            );
+    }
+
+}

--- a/translation/src/test/java/org/opencypher/gremlin/translation/ir/rewrite/RemoveUnusedAliasesTest.java
+++ b/translation/src/test/java/org/opencypher/gremlin/translation/ir/rewrite/RemoveUnusedAliasesTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2018 "Neo4j, Inc." [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opencypher.gremlin.translation.ir.rewrite;
+
+import static org.opencypher.gremlin.translation.helpers.CypherAstAssertions.assertThat;
+import static org.opencypher.gremlin.translation.helpers.CypherAstHelpers.P;
+import static org.opencypher.gremlin.translation.helpers.CypherAstHelpers.__;
+import static org.opencypher.gremlin.translation.helpers.CypherAstHelpers.parse;
+import static org.opencypher.gremlin.translation.helpers.ScalaHelpers.seq;
+
+import org.junit.Test;
+import org.opencypher.gremlin.translation.translator.TranslatorFlavor;
+
+public class RemoveUnusedAliasesTest {
+
+    private final TranslatorFlavor flavor = new TranslatorFlavor(
+        seq(RemoveUnusedAliases$.MODULE$),
+        seq()
+    );
+
+    @Test
+    public void generated() {
+        assertThat(parse(
+            "MATCH (n)-->() " +
+                "RETURN n"
+        ))
+            .withFlavor(flavor)
+            .hasTraversalBeforeReturn(
+                __.V()
+                    .as("n")
+                    .outE().inV()
+                    .select("n")
+            );
+    }
+
+    @Test
+    public void explicit() {
+        assertThat(parse(
+            "MATCH (n)-[r]->(m) " +
+                "RETURN n"
+        ))
+            .withFlavor(flavor)
+            .hasTraversalBeforeReturn(
+                __.V()
+                    .as("n")
+                    .outE().inV()
+                    .select("n")
+            );
+    }
+
+    @Test
+    public void fromTo() {
+        assertThat(parse(
+            "CREATE (n)-[:R]->(m)"
+        ))
+            .withFlavor(flavor)
+            .hasTraversal(
+                __.addV().as("n")
+                    .addV().as("m")
+                    .addE("R").from("n").to("m")
+                    .barrier().limit(0)
+            );
+    }
+
+    @Test
+    public void reAlias() {
+        assertThat(parse(
+            "MATCH (n)-->(m) " +
+                "MATCH (m)-->(k) " +
+                "RETURN n"
+        ))
+            .withFlavor(flavor)
+            .hasTraversalBeforeReturn(
+                __.V()
+                    .as("n")
+                    .outE().inV()
+                    .as("m")
+                    .V()
+                    .as("  GENERATED1").where(__.select("  GENERATED1").where(P.eq("m")))
+                    .outE().inV()
+                    .select("n")
+            );
+    }
+
+}


### PR DESCRIPTION
Adds two rewriting optimizations:

- Removes immediate `select` after `as` with the same step label
- Removes various cases of `as` steps with unused step labels

See added Scaladoc for more details.