### PR TITLE
Expression walker

### DIFF
--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/ListComprehensionTest.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/ListComprehensionTest.java
@@ -24,9 +24,6 @@ import java.util.Map;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.opencypher.gremlin.groups.SkipWithBytecode;
-import org.opencypher.gremlin.groups.SkipWithGremlinGroovy;
 import org.opencypher.gremlin.rules.GremlinServerExternalResource;
 
 public class ListComprehensionTest {
@@ -43,14 +40,7 @@ public class ListComprehensionTest {
         submitAndGet("MATCH (n) DETACH DELETE n;");
     }
 
-    /**
-     * List comprehensions don't work in client-side translations
-     */
     @Test
-    @Category({
-        SkipWithGremlinGroovy.class,
-        SkipWithBytecode.class
-    })
     public void listComprehensionInFirstReturnStatement() throws Exception {
         String cypher = "RETURN [x IN [1, 2.3, true, 'apa'] | toString(x) ] AS list";
 
@@ -62,14 +52,7 @@ public class ListComprehensionTest {
             .containsExactly(asList("1", "2.3", "true", "apa"));
     }
 
-    /**
-     * List comprehensions don't work in client-side translations
-     */
     @Test
-    @Category({
-        SkipWithGremlinGroovy.class,
-        SkipWithBytecode.class
-    })
     public void simplestCaseOfListComprehension() throws Exception {
         String cypher = "WITH [2, 2.9] AS numbers\n" +
             " RETURN [n IN numbers | toInteger(n)] AS int_numbers";
@@ -82,14 +65,7 @@ public class ListComprehensionTest {
             .containsExactly(asList(2L, 2L));
     }
 
-    /**
-     * List comprehensions don't work in client-side translations
-     */
     @Test
-    @Category({
-        SkipWithGremlinGroovy.class,
-        SkipWithBytecode.class
-    })
     public void applyMultipleFunctions() throws Exception {
         String cypher = "WITH [2, 2.9] AS numbers\n" +
             " RETURN [n IN numbers | toString(toInteger(n))] AS int_numbers";
@@ -102,14 +78,7 @@ public class ListComprehensionTest {
             .containsExactly(asList("2", "2"));
     }
 
-    /**
-     * List comprehensions don't work in client-side translations
-     */
     @Test
-    @Category({
-        SkipWithGremlinGroovy.class,
-        SkipWithBytecode.class
-    })
     public void patternComprehension() throws Exception {
         submitAndGet("CREATE (a:Person { name: 'Charlie Sheen' })\n" +
             "CREATE (m1:Movie { name: 'Wall Street', year: 1987 })\n" +

--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/ListComprehensionTest.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/ListComprehensionTest.java
@@ -134,14 +134,17 @@ public class ListComprehensionTest {
 
     @Test
     public void pathInPatternComprehension() throws Exception {
-        submitAndGet("CREATE (a:A), (b:B)\n" +
-            "CREATE (a)-[:T]->(b)");
+        submitAndGet("CREATE (:A)-[:T]->(:B)");
 
-        String cypher = "MATCH (a:A), (b:B)\n" +
-            "RETURN [p = (a)-[*]->(b) | p] AS paths";
+        String cypher = "MATCH (a:A), (b:B) " +
+            "WITH [p = (a)-[*]->(b) | p] AS paths, count(a) AS c " +
+            "RETURN paths, c";
 
         List<Map<String, Object>> results = submitAndGet(cypher);
 
+        assertThat(results)
+            .extracting("c")
+            .containsExactly(1L);
         assertThat(results)
             .extracting("paths")
             .hasSize(1)

--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/ReturnTest.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/ReturnTest.java
@@ -396,6 +396,17 @@ public class ReturnTest {
     }
 
     @Test
+    public void returnRange() throws Exception {
+        List<Map<String, Object>> results = submitAndGet(
+            "RETURN range(1, 5) AS r"
+        );
+
+        assertThat(results)
+            .extracting("r")
+            .containsExactly(asList(1L, 2L, 3L, 4L, 5L));
+    }
+
+    @Test
     public void ternaryLogic() throws Exception {
         Map<String, Object> args = new HashMap<>();
         args.put("t", true);

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/translator/TranslatorFlavor.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/translator/TranslatorFlavor.scala
@@ -40,7 +40,7 @@ object TranslatorFlavor {
     rewriters = Seq(
       InlineMapTraversal,
       GroupStepFilters,
-      RemoveImmediateReselect,
+      RemoveUselessSteps,
       RemoveUnusedAliases
     ),
     postConditions = Nil)

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/walker/ExpressionWalker.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/walker/ExpressionWalker.scala
@@ -1,0 +1,248 @@
+/*
+ * Copyright (c) 2018 "Neo4j, Inc." [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opencypher.gremlin.translation.walker
+
+import org.apache.tinkerpop.gremlin.structure.{Column, Vertex}
+import org.neo4j.cypher.internal.frontend.v3_3.ast._
+import org.opencypher.gremlin.translation.GremlinSteps
+import org.opencypher.gremlin.translation.Tokens._
+import org.opencypher.gremlin.translation.context.StatementContext
+import org.opencypher.gremlin.translation.exception.SyntaxException
+import org.opencypher.gremlin.translation.walker.NodeUtils.expressionValue
+import org.opencypher.gremlin.traversal.CustomFunction
+
+/**
+  * AST walker that handles translation
+  * of evaluable expression nodes in the Cypher AST.
+  */
+object ExpressionWalker {
+  def walk[T, P](context: StatementContext[T, P], g: GremlinSteps[T, P], node: Expression): Unit = {
+    new ExpressionWalker(context, g).walk(node)
+  }
+
+  def walkLocal[T, P](context: StatementContext[T, P], g: GremlinSteps[T, P], node: Expression): GremlinSteps[T, P] = {
+    new ExpressionWalker(context, g).walkLocal(node)
+  }
+}
+
+private class ExpressionWalker[T, P](context: StatementContext[T, P], g: GremlinSteps[T, P]) {
+  def walk(node: Expression): Unit = {
+    g.map(walkLocal(node))
+  }
+
+  private def __ = g.start()
+
+  private def walkLocal(expression: Expression): GremlinSteps[T, P] = {
+    val p = context.dsl.predicates()
+
+    expression match {
+      case Variable(varName) =>
+        __.select(varName)
+
+      case Property(Variable(varName), PropertyKeyName(keyName: String)) =>
+        __.select(varName)
+          .map(
+            notNull(
+              __.coalesce(
+                __.values(keyName),
+                __.constant(NULL)
+              )))
+
+      case HasLabels(Variable(varName), List(LabelName(label))) =>
+        __.select(varName)
+          .map(notNull(anyMatch(__.hasLabel(label))))
+
+      case IsNull(expr) =>
+        walkLocal(expr).map(anyMatch(__.is(p.isEq(NULL))))
+
+      case IsNotNull(expr) =>
+        walkLocal(expr).map(anyMatch(__.is(p.neq(NULL))))
+
+      case Not(rhs) =>
+        val rhsT = walkLocal(rhs)
+        __.choose(
+          copy(rhsT).is(p.isEq(NULL)),
+          __.constant(NULL),
+          __.choose(
+            copy(rhsT).is(p.isEq(true)),
+            __.constant(false),
+            __.constant(true)
+          )
+        )
+
+      case Ands(ands) =>
+        val traversals = ands.map(walkLocal).toSeq
+        __.choose(
+          __.and(traversals.map(copy).map(_.is(p.isEq(true))): _*),
+          __.constant(true),
+          __.choose(
+            __.or(traversals.map(copy).map(_.is(p.isEq(false))): _*),
+            __.constant(false),
+            __.constant(NULL)
+          )
+        )
+
+      case Ors(ors) =>
+        val traversals = ors.map(walkLocal).toSeq
+        __.choose(
+          __.or(traversals.map(copy).map(_.is(p.isEq(true))): _*),
+          __.constant(true),
+          __.choose(
+            __.and(traversals.map(copy).map(_.is(p.isEq(false))): _*),
+            __.constant(false),
+            __.constant(NULL)
+          )
+        )
+
+      case Xor(lhs, rhs) =>
+        val lhsT = walkLocal(lhs)
+        val rhsT = walkLocal(rhs)
+        __.choose(
+          __.or(copy(lhsT).is(p.isEq(NULL)), copy(rhsT).is(p.isEq(NULL))),
+          __.constant(NULL),
+          __.choose(
+            copy(rhsT).as(TEMP).map(lhsT).where(p.neq(TEMP)),
+            __.constant(true),
+            __.constant(false)
+          )
+        )
+
+      case Add(lhs, rhs)      => math(lhs, rhs, "+")
+      case Subtract(lhs, rhs) => math(lhs, rhs, "-")
+      case Multiply(lhs, rhs) => math(lhs, rhs, "*")
+      case Divide(lhs, rhs)   => math(lhs, rhs, "/")
+      case Pow(lhs, rhs)      => math(lhs, rhs, "^")
+      case Modulo(lhs, rhs)   => math(lhs, rhs, "%")
+
+      case ContainerIndex(expr, idx) =>
+        val index = expressionValue(idx, context)
+        walkLocal(expr).map(CustomFunction.containerIndex(index))
+
+      case FunctionInvocation(_, FunctionName(fnName), distinct, args) =>
+        val traversals = args.map(walkLocal)
+        val traversal = fnName.toLowerCase match {
+          case "abs"           => traversals.head.math("abs(_)")
+          case "exists"        => traversals.head.map(anyMatch(__.is(p.neq(NULL))))
+          case "coalesce"      => __.coalesce(traversals.init.map(_.is(p.neq(NULL))) :+ traversals.last: _*)
+          case "id"            => traversals.head.map(notNull(__.id()))
+          case "keys"          => traversals.head.valueMap().select(Column.keys)
+          case "labels"        => traversals.head.label().is(p.neq(Vertex.DEFAULT_LABEL)).fold()
+          case "length"        => traversals.head.map(CustomFunction.length())
+          case "nodes"         => traversals.head.map(CustomFunction.nodes())
+          case "properties"    => traversals.head.map(notNull(__.map(CustomFunction.properties())))
+          case "relationships" => traversals.head.map(CustomFunction.relationships())
+          case "size"          => traversals.head.map(CustomFunction.size())
+          case "sqrt"          => traversals.head.math("sqrt(_)")
+          case "type"          => traversals.head.map(notNull(__.label().is(p.neq(Vertex.DEFAULT_LABEL))))
+          case "toboolean"     => traversals.head.map(CustomFunction.convertToBoolean())
+          case "tofloat"       => traversals.head.map(CustomFunction.convertToFloat())
+          case "tointeger"     => traversals.head.map(CustomFunction.convertToIntegerType())
+          case "tostring"      => traversals.head.map(CustomFunction.convertToString())
+          case _ =>
+            throw new SyntaxException(s"Unknown function '$fnName'")
+        }
+        if (distinct) {
+          throw new SyntaxException("Invalid use of DISTINCT with function '" + fnName + "'")
+        }
+        traversal
+
+      case ListComprehension(ExtractScope(_, _, Some(function)), target) if function.dependencies.size == 1 =>
+        val targetT = walkLocal(target)
+        val functionT = walkLocal(function)
+
+        val Variable(dependencyName) = function.dependencies.head
+        targetT.unfold().as(dependencyName).map(functionT).fold()
+
+      case PatternComprehension(_, RelationshipsPattern(relationshipChain), maybeExpression, projection, _) =>
+        val varName = patternComprehensionPath(relationshipChain, maybeExpression, projection)
+        val traversal = __.select(varName)
+
+        projection match {
+          case PathExpression(_) =>
+            traversal.map(CustomFunction.pathComprehension())
+          case expression: Expression =>
+            val functionT = walkLocal(expression)
+            if (expression.dependencies.isEmpty) {
+              traversal.unfold().map(functionT).fold()
+            } else if (expression.dependencies.size == 1) {
+              val Variable(dependencyName) = expression.dependencies.head
+              traversal.unfold().as(dependencyName).map(functionT).fold()
+            } else {
+              context.unsupported("pattern comprehension with multiple arguments", expression)
+            }
+        }
+
+      case _ =>
+        __.constant(expressionValue(expression, context))
+    }
+  }
+
+  private def copy(traversal: GremlinSteps[T, P]): GremlinSteps[T, P] = {
+    __.map(traversal)
+  }
+
+  private def notNull(traversal: GremlinSteps[T, P]): GremlinSteps[T, P] = {
+    val p = context.dsl.predicates()
+    __.choose(p.neq(NULL), traversal, __.constant(NULL))
+  }
+
+  private def anyMatch(traversal: GremlinSteps[T, P]): GremlinSteps[T, P] = {
+    __.choose(
+      traversal,
+      __.constant(true),
+      __.constant(false)
+    )
+  }
+
+  private def math(lhs: Expression, rhs: Expression, op: String): GremlinSteps[T, P] = {
+    val p = context.dsl.predicates()
+
+    val lhsT = walkLocal(lhs)
+    val rhsT = walkLocal(rhs)
+
+    val lhsName = context.generateName().replace(" ", "_") // name limited by MathStep#VARIABLE_PATTERN
+
+    lhsT
+      .as(lhsName)
+      .map(rhsT)
+      .choose(
+        __.or(__.is(p.isEq(NULL)), __.select(lhsName).is(p.isEq(NULL))),
+        __.constant(NULL),
+        __.math(s"$lhsName $op _")
+      )
+  }
+
+  private def patternComprehensionPath(
+      relationshipChain: RelationshipChain,
+      maybePredicate: Option[Expression],
+      projection: Expression): String = {
+    val select = __
+    val contextWhere = context.copy()
+    WhereWalker.walkRelationshipChain(contextWhere, select, relationshipChain)
+    maybePredicate.foreach(WhereWalker.walk(contextWhere, select, _))
+
+    if (projection.isInstanceOf[PathExpression]) {
+      select.path()
+    }
+
+    val name = contextWhere.generateName()
+    g.sideEffect(
+      select.aggregate(name)
+    )
+
+    name
+  }
+}

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/walker/UnwindWalker.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/walker/UnwindWalker.scala
@@ -17,14 +17,10 @@ package org.opencypher.gremlin.translation.walker
 
 import java.util.Collections
 
-import org.apache.tinkerpop.gremlin.structure.{Column, Vertex}
 import org.neo4j.cypher.internal.frontend.v3_3.ast._
+import org.opencypher.gremlin.translation.GremlinSteps
+import org.opencypher.gremlin.translation.Tokens._
 import org.opencypher.gremlin.translation.context.StatementContext
-import org.opencypher.gremlin.translation.exception.SyntaxException
-import org.opencypher.gremlin.translation.walker.NodeUtils.expressionValue
-import org.opencypher.gremlin.translation.{GremlinSteps, Tokens}
-
-import scala.collection.immutable.NumericRange
 
 /**
   * AST walker that handles translation
@@ -39,74 +35,18 @@ object UnwindWalker {
 
 private class UnwindWalker[T, P](context: StatementContext[T, P], g: GremlinSteps[T, P]) {
 
-  private val injectHardLimit = 10000
-
   def walkClause(node: Unwind): Unit = {
-    val p = context.dsl.predicates()
-
-    if (context.isFirstStatement) {
-      context.markFirstStatement()
-    } else {
-      val p = context.dsl.predicates()
-      g.is(p.neq(Tokens.START))
-    }
-
     val Unwind(expression, Variable(varName)) = node
     expression match {
-      case ListLiteral(list) =>
-        val values = list
-          .map(expressionValue(_, context))
-          .asInstanceOf[Seq[Object]]
-        g.inject(values: _*).as(varName)
-      case FunctionInvocation(_, FunctionName(fnName), _, args) if "range" == fnName.toLowerCase =>
-        val range: NumericRange[Long] = args match {
-          case Seq(start: IntegerLiteral, end: IntegerLiteral) =>
-            NumericRange.inclusive(start.value, end.value, 1)
-          case Seq(start: IntegerLiteral, end: IntegerLiteral, step: IntegerLiteral) =>
-            NumericRange.inclusive(start.value, end.value, step.value)
-        }
-        walkRange(range, varName)
-      case FunctionInvocation(_, FunctionName(fnName), _, Vector(arg)) =>
-        arg match {
-          case Variable(name) => g.select(name)
-          case _              => g.inject(expressionValue(arg, context))
-        }
-        fnName.toLowerCase match {
-          case "labels" => g.label().is(p.neq(Vertex.DEFAULT_LABEL)).as(varName)
-          case "keys"   => g.valueMap().select(Column.keys).unfold().as(varName)
-          case _        => throw new SyntaxException(s"Unknown function '$fnName'")
-        }
-      case FunctionInvocation(_, FunctionName(fnName), _, _) =>
-        throw new SyntaxException(s"Unknown function '$fnName'")
-      case Variable(name) =>
-        g.select(name).unfold().as(varName)
       case Null() =>
         g.inject(Collections.emptyList).unfold().as(varName)
       case _: Expression =>
-        g.inject(expressionValue(expression, context)).unfold().as(varName)
-    }
-  }
-
-  private def walkRange(range: NumericRange[Long], varName: String) = {
-    context.precondition(
-      range.length <= injectHardLimit,
-      s"Range is too big (must be less than or equal to $injectHardLimit)",
-      range
-    )
-
-    if (range.step == 1) {
-      val rangeLabel = context.generateName()
-      g.inject(Tokens.START)
-        .repeat(g.start().loops().aggregate(rangeLabel))
-        .times((range.end + 1).toInt)
-        .cap(rangeLabel)
-        .unfold()
-        .skip(range.start)
-        .limit(range.end - range.start + 1)
-        .as(varName)
-    } else {
-      val numbers = range.asInstanceOf[Seq[Object]]
-      g.inject(numbers: _*).as(varName)
+        if (context.isFirstStatement) {
+          context.markFirstStatement()
+          g.inject(START)
+        }
+        ExpressionWalker.walk(context, g, expression)
+        g.unfold().as(varName)
     }
   }
 }

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/walker/WhereWalker.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/walker/WhereWalker.scala
@@ -139,7 +139,7 @@ private class WhereWalker[T, P](context: StatementContext[T, P], g: GremlinSteps
   }
 
   private def expressionPredicate(p: AnyRef => P): Expression => P = { expression =>
-    p(expressionValue(expression, context).asInstanceOf[AnyRef])
+    p(expressionValue(expression, context))
   }
 
   private def seqExpressionPredicate(p: Seq[AnyRef] => P): Expression => P = { expression =>

--- a/translation/src/test/java/org/opencypher/gremlin/translation/helpers/CypherAstAssert.java
+++ b/translation/src/test/java/org/opencypher/gremlin/translation/helpers/CypherAstAssert.java
@@ -70,8 +70,9 @@ public class CypherAstAssert extends AbstractAssert<CypherAstAssert, CypherAstWr
     private static final Pattern RETURN_START = Pattern.compile(
         "\\.(" +
             "group\\(\\)\\.by\\([^)]+\\)\\.by\\([^)]+\\)|" +
-            "map\\(__\\.project|" +
-            "fold\\(\\)\\.map\\(__\\.project" +
+            "fold\\(\\)\\.map\\(__\\.project\\(|" +
+            "map\\(__\\.project\\(|" +
+            "(?<=[^_]\\.)project\\(" +
             ")"
     );
 
@@ -83,7 +84,7 @@ public class CypherAstAssert extends AbstractAssert<CypherAstAssert, CypherAstWr
             while (matcher.find()) {
                 lastIndex = matcher.start();
             }
-            return t.substring(0, lastIndex);
+            return lastIndex == -1 ? t : t.substring(0, lastIndex);
         });
     }
 

--- a/translation/src/test/java/org/opencypher/gremlin/translation/helpers/ScalaHelpers.java
+++ b/translation/src/test/java/org/opencypher/gremlin/translation/helpers/ScalaHelpers.java
@@ -28,6 +28,6 @@ public final class ScalaHelpers {
         for (T value : values) {
             list = list.$colon$colon(value);
         }
-        return list;
+        return list.reverse();
     }
 }

--- a/translation/src/test/java/org/opencypher/gremlin/translation/ir/rewrite/CosmosDbFlavorTest.java
+++ b/translation/src/test/java/org/opencypher/gremlin/translation/ir/rewrite/CosmosDbFlavorTest.java
@@ -43,9 +43,13 @@ public class CosmosDbFlavorTest {
             .hasTraversal(
                 __.V().as("n").where(__.select("n").hasLabel("N")).as(UNUSED)
                     .select("n", UNUSED)
-                    .map(__.project("n.p").by(__.select("n").choose(P.neq(NULL), __.coalesce(
-                        __.properties().hasKey("p").value(),
-                        __.constant(NULL)), __.constant(NULL))))
+                    .map(__.project("n.p").by(
+                        __.select("n").map(__.choose(
+                            P.neq(NULL),
+                            __.coalesce(
+                                __.properties().hasKey("p").value(),
+                                __.constant(NULL)),
+                            __.constant(NULL)))))
             );
     }
 

--- a/translation/src/test/java/org/opencypher/gremlin/translation/ir/rewrite/CosmosDbFlavorTest.java
+++ b/translation/src/test/java/org/opencypher/gremlin/translation/ir/rewrite/CosmosDbFlavorTest.java
@@ -29,7 +29,11 @@ import org.opencypher.gremlin.translation.translator.TranslatorFlavor;
 public class CosmosDbFlavorTest {
 
     private final TranslatorFlavor flavor = new TranslatorFlavor(
-        seq(CosmosDbFlavor$.MODULE$),
+        seq(
+            InlineMapTraversal$.MODULE$,
+            RemoveUselessSteps$.MODULE$,
+            CosmosDbFlavor$.MODULE$
+        ),
         seq()
     );
 
@@ -43,13 +47,13 @@ public class CosmosDbFlavorTest {
             .hasTraversal(
                 __.V().as("n").where(__.select("n").hasLabel("N")).as(UNUSED)
                     .select("n", UNUSED)
-                    .map(__.project("n.p").by(
-                        __.select("n").map(__.choose(
+                    .project("n.p").by(
+                        __.select("n").choose(
                             P.neq(NULL),
                             __.coalesce(
                                 __.properties().hasKey("p").value(),
                                 __.constant(NULL)),
-                            __.constant(NULL)))))
+                            __.constant(NULL)))
             );
     }
 


### PR DESCRIPTION
Evaluable expression node processing has been extracted to `ExpressionWalker`. This walker can be re-used in other contexts where expression AST nodes are found, except for expressions in predicates (e.g. `WhereWalker`, currently).

`ExpressionWalker` has only been applied in `RETURN` and `UNWIND` translations, but more should follow.

+1 TCK