### PR TITLE
Model collection literals as projections

### DIFF
--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/ContainerIndexTest.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/ContainerIndexTest.java
@@ -54,6 +54,7 @@ public class ContainerIndexTest {
             .containsExactly("2");
     }
 
+    @Test
     public void mapIndexInReturn() throws Exception {
         List<Map<String, Object>> results = submitAndGet(
             "WITH {foo: 1, bar: 2, baz: 3} AS map\n" +
@@ -64,6 +65,7 @@ public class ContainerIndexTest {
             .containsExactly(2L);
     }
 
+    @Test
     public void mapIndexInReturnFunction() throws Exception {
         List<Map<String, Object>> results = submitAndGet(
             "WITH {foo: 1, bar: 2, baz: 3} AS map\n" +

--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/ContainerIndexTest.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/ContainerIndexTest.java
@@ -21,9 +21,6 @@ import java.util.List;
 import java.util.Map;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.opencypher.gremlin.groups.SkipWithBytecode;
-import org.opencypher.gremlin.groups.SkipWithGremlinGroovy;
 import org.opencypher.gremlin.rules.GremlinServerExternalResource;
 
 public class ContainerIndexTest {
@@ -57,14 +54,6 @@ public class ContainerIndexTest {
             .containsExactly("2");
     }
 
-    /**
-     * Maps don't work in client-side translations
-     */
-    @Test
-    @Category({
-        SkipWithGremlinGroovy.class,
-        SkipWithBytecode.class
-    })
     public void mapIndexInReturn() throws Exception {
         List<Map<String, Object>> results = submitAndGet(
             "WITH {foo: 1, bar: 2, baz: 3} AS map\n" +
@@ -75,14 +64,6 @@ public class ContainerIndexTest {
             .containsExactly(2L);
     }
 
-    /**
-     * Maps don't work in client-side translations
-     */
-    @Test
-    @Category({
-        SkipWithGremlinGroovy.class,
-        SkipWithBytecode.class
-    })
     public void mapIndexInReturnFunction() throws Exception {
         List<Map<String, Object>> results = submitAndGet(
             "WITH {foo: 1, bar: 2, baz: 3} AS map\n" +

--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/CreateTest.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/CreateTest.java
@@ -309,6 +309,7 @@ public class CreateTest {
             .containsExactly(asList(1L, 2L, 3L));
     }
 
+    @Test
     public void createMapProperty() throws Exception {
         List<Map<String, Object>> results = submitAndGet(
             "CREATE (n {foo: {foo: 'bar', baz: 'qux'}}) RETURN n.foo AS f"

--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/CreateTest.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/CreateTest.java
@@ -36,9 +36,6 @@ import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.opencypher.gremlin.groups.SkipWithBytecode;
-import org.opencypher.gremlin.groups.SkipWithGremlinGroovy;
 import org.opencypher.gremlin.rules.GremlinServerExternalResource;
 
 public class CreateTest {
@@ -312,14 +309,6 @@ public class CreateTest {
             .containsExactly(asList(1L, 2L, 3L));
     }
 
-    /**
-     * Maps don't work in client-side translations
-     */
-    @Test
-    @Category({
-        SkipWithGremlinGroovy.class,
-        SkipWithBytecode.class
-    })
     public void createMapProperty() throws Exception {
         List<Map<String, Object>> results = submitAndGet(
             "CREATE (n {foo: {foo: 'bar', baz: 'qux'}}) RETURN n.foo AS f"

--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/DeleteTest.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/DeleteTest.java
@@ -77,6 +77,52 @@ public class DeleteTest {
     }
 
     @Test
+    public void detachDeletePath() throws Exception {
+        List<Map<String, Object>> beforeDelete = submitAndGet(
+            "MATCH (n) RETURN count(*)"
+        );
+        List<Map<String, Object>> onDelete = submitAndGet(
+            "MATCH p = (:software)<-[:created]-() DETACH DELETE p"
+        );
+        List<Map<String, Object>> afterDelete = submitAndGet(
+            "MATCH (n) RETURN count(*)"
+        );
+
+        assertThat(beforeDelete)
+            .extracting("count(*)")
+            .containsExactly(6L);
+        assertThat(onDelete)
+            .isEmpty();
+        assertThat(afterDelete)
+            .extracting("count(*)")
+            .containsExactly(1L);
+    }
+
+    @Test
+    public void detachDeleteFromAList() throws Exception {
+        List<Map<String, Object>> beforeDelete = submitAndGet(
+            "MATCH (n) RETURN count(*)"
+        );
+        List<Map<String, Object>> onDelete = submitAndGet(
+            "MATCH (n) " +
+                "WITH [n] AS nodes " +
+                "DETACH DELETE nodes[0]"
+        );
+        List<Map<String, Object>> afterDelete = submitAndGet(
+            "MATCH (n) RETURN count(*)"
+        );
+
+        assertThat(beforeDelete)
+            .extracting("count(*)")
+            .containsExactly(6L);
+        assertThat(onDelete)
+            .isEmpty();
+        assertThat(afterDelete)
+            .extracting("count(*)")
+            .containsExactly(0L);
+    }
+
+    @Test
     public void deleteWithReturn() throws Exception {
         submitAndGet("MATCH (n) DETACH DELETE n");
         submitAndGet("CREATE ()-[:R]->()");
@@ -111,7 +157,7 @@ public class DeleteTest {
         submitAndGet(
             "MATCH (n)\n" +
                 "OPTIONAL MATCH (n)-[r]-()\n" +
-                "DELETE n, r"
+                "DELETE r, n"
         );
         List<Map<String, Object>> afterDelete = submitAndGet(
             "MATCH (n) RETURN count(*)"

--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/LiteralTest.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/LiteralTest.java
@@ -23,6 +23,7 @@ import static org.opencypher.gremlin.test.GremlinExtractors.byElementProperty;
 import static org.opencypher.gremlin.translation.groovy.StringTranslationUtils.toLiteral;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -137,5 +138,32 @@ public class LiteralTest {
 
         assertThat(results)
             .containsExactly(literalMap);
+    }
+
+    @Test
+    public void returnEmptyMap() {
+        List<Map<String, Object>> results = submitAndGet(
+            "RETURN {} AS map"
+        );
+
+        assertThat(results)
+            .extracting("map")
+            .containsExactly(new HashMap<>());
+    }
+
+    @Test
+    public void returnMap() {
+        List<Map<String, Object>> results = submitAndGet(
+            "RETURN {k1: 12, k2: 'Hello', k3: true} AS map"
+        );
+
+        Map<String, Object> map = new HashMap<>();
+        map.put("k1", 12L);
+        map.put("k2", "Hello");
+        map.put("k3", true);
+
+        assertThat(results)
+            .extracting("map")
+            .containsExactly(map);
     }
 }

--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/LiteralTest.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/LiteralTest.java
@@ -56,6 +56,7 @@ public class LiteralTest {
         literalMap.put("p8", asList(13L, -40000L));
         literalMap.put("p9", asList("Hello", "World"));
         literalMap.put("p10", asList(true, false));
+        literalMap.put("p11", new ArrayList<>());
     }
 
     private List<Map<String, Object>> submitAndGet(String cypher) {

--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/NativeTraversalTest.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/NativeTraversalTest.java
@@ -33,9 +33,6 @@ import org.assertj.core.groups.Tuple;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.opencypher.gremlin.groups.SkipWithBytecode;
-import org.opencypher.gremlin.groups.SkipWithGremlinGroovy;
 import org.opencypher.gremlin.rules.GremlinServerExternalResource;
 
 public class NativeTraversalTest {
@@ -114,14 +111,6 @@ public class NativeTraversalTest {
             .containsExactly("1.0");
     }
 
-    /**
-     * Maps don't work in client-side translations
-     */
-    @Test
-    @Category({
-        SkipWithGremlinGroovy.class,
-        SkipWithBytecode.class
-    })
     public void mapLiteral() throws Exception {
         List<Map<String, Object>> results = submitAndGet(
             "WITH {name: 'Matz', name2: 'Pontus'} AS map\n" +

--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/NativeTraversalTest.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/NativeTraversalTest.java
@@ -111,6 +111,7 @@ public class NativeTraversalTest {
             .containsExactly("1.0");
     }
 
+    @Test
     public void mapLiteral() throws Exception {
         List<Map<String, Object>> results = submitAndGet(
             "WITH {name: 'Matz', name2: 'Pontus'} AS map\n" +

--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/ReturnTest.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/ReturnTest.java
@@ -289,6 +289,19 @@ public class ReturnTest {
     }
 
     @Test
+    public void propertiesFunctionOnAMap() throws Exception {
+        List<Map<String, Object>> results = submitAndGet(
+            "RETURN properties({name: 'Popeye', level: 9001}) AS m"
+        );
+
+        assertThat(results)
+            .extracting("m")
+            .containsExactly(
+                ImmutableMap.of("name", "Popeye", "level", 9001L)
+            );
+    }
+
+    @Test
     public void distinctLabels() throws Exception {
         List<Map<String, Object>> results = submitAndGet(
             "MATCH (n) RETURN DISTINCT labels(n) AS labels"

--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/SetTest.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/SetTest.java
@@ -27,9 +27,6 @@ import java.util.Map;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.opencypher.gremlin.groups.SkipWithBytecode;
-import org.opencypher.gremlin.groups.SkipWithGremlinGroovy;
 import org.opencypher.gremlin.rules.GremlinServerExternalResource;
 
 public class SetTest {
@@ -67,14 +64,6 @@ public class SetTest {
         assertThat(setAndGetProperty("[1, 2, 3]")).containsExactly(asList(1L, 2L, 3L));
     }
 
-    /**
-     * Maps don't work in client-side translations
-     */
-    @Test
-    @Category({
-        SkipWithGremlinGroovy.class,
-        SkipWithBytecode.class
-    })
     public void setAndGetMap() throws Exception {
         assertThat(setAndGetProperty("{key: 'value'}")).containsExactly(singletonMap("key", "value"));
     }

--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/SetTest.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/SetTest.java
@@ -64,6 +64,7 @@ public class SetTest {
         assertThat(setAndGetProperty("[1, 2, 3]")).containsExactly(asList(1L, 2L, 3L));
     }
 
+    @Test
     public void setAndGetMap() throws Exception {
         assertThat(setAndGetProperty("{key: 'value'}")).containsExactly(singletonMap("key", "value"));
     }

--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/WithTest.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/WithTest.java
@@ -69,6 +69,7 @@ public class WithTest {
             .containsExactlyInAnyOrder("marko", "vadas");
     }
 
+    @Test
     public void withMap() throws Exception {
         assertThat(returnWith("map").toString()).isEqualTo("{name=Mats}");
         assertThat(returnWith("map.name")).isEqualTo("Mats");
@@ -82,6 +83,7 @@ public class WithTest {
         return getResult(format(queryTemplate, returnExpression));
     }
 
+    @Test
     public void withMapWithNullValue() throws Exception {
         String query = "WITH {notName: 0, notName2: null} AS map " +
             "RETURN exists(map.notName2) AS result";

--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/WithTest.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/WithTest.java
@@ -23,9 +23,6 @@ import java.util.List;
 import java.util.Map;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.opencypher.gremlin.groups.SkipWithBytecode;
-import org.opencypher.gremlin.groups.SkipWithGremlinGroovy;
 import org.opencypher.gremlin.rules.GremlinServerExternalResource;
 
 public class WithTest {
@@ -72,14 +69,6 @@ public class WithTest {
             .containsExactlyInAnyOrder("marko", "vadas");
     }
 
-    /**
-     * Maps don't work in client-side translations
-     */
-    @Test
-    @Category({
-        SkipWithGremlinGroovy.class,
-        SkipWithBytecode.class
-    })
     public void withMap() throws Exception {
         assertThat(returnWith("map").toString()).isEqualTo("{name=Mats}");
         assertThat(returnWith("map.name")).isEqualTo("Mats");
@@ -93,14 +82,6 @@ public class WithTest {
         return getResult(format(queryTemplate, returnExpression));
     }
 
-    /**
-     * Maps don't work in client-side translations
-     */
-    @Test
-    @Category({
-        SkipWithGremlinGroovy.class,
-        SkipWithBytecode.class
-    })
     public void withMapWithNullValue() throws Exception {
         String query = "WITH {notName: 0, notName2: null} AS map " +
             "RETURN exists(map.notName2) AS result";

--- a/translation/src/main/java/org/opencypher/gremlin/translation/groovy/StringTranslationUtils.java
+++ b/translation/src/main/java/org/opencypher/gremlin/translation/groovy/StringTranslationUtils.java
@@ -17,14 +17,10 @@ package org.opencypher.gremlin.translation.groovy;
 
 import static java.util.stream.Collectors.joining;
 
-import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.apache.tinkerpop.gremlin.structure.Property;
-import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedVertexProperty;
 
 public final class StringTranslationUtils {
     private StringTranslationUtils() {
@@ -47,15 +43,12 @@ public final class StringTranslationUtils {
                 .map(StringTranslationUtils::toLiteral)
                 .collect(Collectors.joining(", ", "[", "]"));
         }
-        if (argument instanceof DetachedVertexProperty) {
-            Map<String, Object> map = new HashMap<>();
-            Iterator<Property<Object>> properties = ((DetachedVertexProperty<?>) argument).properties();
-            properties
-                .forEachRemaining(e -> map.put(e.key(), e.value()));
-            return toLiteral(map);
-        }
         if (argument instanceof Map) {
-            return ((Map<?, ?>) argument).entrySet().stream()
+            Map<?, ?> map = (Map<?, ?>) argument;
+            if (map.isEmpty()) {
+                return "[:]";
+            }
+            return map.entrySet().stream()
                 .map(entry -> {
                     Object key = entry.getKey();
                     Object value = toLiteral(entry.getValue());

--- a/translation/src/main/java/org/opencypher/gremlin/traversal/CustomFunction.java
+++ b/translation/src/main/java/org/opencypher/gremlin/traversal/CustomFunction.java
@@ -42,7 +42,6 @@ import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalUtil;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Property;
-import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.opencypher.gremlin.translation.Tokens;
 import org.opencypher.gremlin.translation.exception.TypeException;
@@ -161,7 +160,11 @@ public class CustomFunction implements Function<Traverser, Object> {
         return new CustomFunction(
             "properties",
             traverser -> {
-                Iterator<? extends Property<Object>> it = ((Element) traverser.get()).properties();
+                Object argument = traverser.get();
+                if (argument instanceof Map) {
+                    return argument;
+                }
+                Iterator<? extends Property<Object>> it = ((Element) argument).properties();
                 Map<Object, Object> propertyMap = new HashMap<>();
                 while (it.hasNext()) {
                     Property<Object> property = it.next();

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/context/StatementContext.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/context/StatementContext.scala
@@ -15,6 +15,7 @@
  */
 package org.opencypher.gremlin.translation.context
 
+import org.neo4j.cypher.internal.frontend.v3_3.ast.Expression
 import org.neo4j.cypher.internal.frontend.v3_3.symbols.CypherType
 import org.opencypher.gremlin.translation.GremlinSteps
 import org.opencypher.gremlin.translation.translator.Translator
@@ -24,9 +25,10 @@ import scala.collection.mutable
 object StatementContext {
   def apply[T, P](
       dsl: Translator[T, P],
+      expressionTypes: Map[Expression, CypherType],
       returnTypes: Map[String, CypherType],
       extractedParameters: Map[String, Any]): StatementContext[T, P] = {
-    new StatementContext(dsl, returnTypes, extractedParameters)
+    new StatementContext(dsl, expressionTypes, returnTypes, extractedParameters)
   }
 }
 
@@ -34,11 +36,13 @@ object StatementContext {
   * Context used by AST walkers to share global translation state.
   *
   * @param dsl                 reference to [[Translator]] implementation in use
+  * @param expressionTypes     expression Cypher types
   * @param returnTypes         return types by alias
   * @param extractedParameters Cypher query parameters
   */
 sealed class StatementContext[T, P](
     val dsl: Translator[T, P],
+    val expressionTypes: Map[Expression, CypherType],
     val returnTypes: Map[String, CypherType],
     private val extractedParameters: Map[String, Any]) {
 
@@ -114,7 +118,7 @@ sealed class StatementContext[T, P](
   }
 
   def copy(): StatementContext[T, P] = {
-    val result = StatementContext(dsl, returnTypes, extractedParameters)
+    val result = StatementContext(dsl, expressionTypes, returnTypes, extractedParameters)
     result.referencedAliases ++= referencedAliases
     result.nameGenerator = nameGenerator
     result

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/SimplifyPropertySetters.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/SimplifyPropertySetters.scala
@@ -42,9 +42,12 @@ object SimplifyPropertySetters extends GremlinRewriter {
         } else {
           PropertyV(key, value) :: rest
         }
-      case ChooseT(_, prop @ PropertyT(_, Project(_*) :: valueTail) :: Nil, _) :: rest
-          if valueTail.init.forall(_.isInstanceOf[By]) && valueTail.last.isInstanceOf[SelectC] =>
-        prop ++ rest
+      case step @ ChooseT(_, prop @ PropertyT(_, Project(_*) :: valueTail) :: Nil, _) :: rest
+          if valueTail.init.forall(_.isInstanceOf[By]) =>
+        valueTail.last match {
+          case _: By | _: SelectC => prop ++ rest
+          case _                  => step
+        }
     }))(steps)
   }
 }

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/SimplifyPropertySetters.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/SimplifyPropertySetters.scala
@@ -29,7 +29,9 @@ object SimplifyPropertySetters extends GremlinRewriter {
 
   override def apply(steps: Seq[GremlinStep]): Seq[GremlinStep] = {
     mapTraversals(replace({
-      case ChooseT(_, PropertyT(key, Constant(value) :: Nil) :: Nil, drop) :: rest =>
+      case PropertyT(key, Constant(value) :: Nil) :: rest =>
+        PropertyV(key, value) :: rest
+      case ChooseT(_, PropertyV(key, value) :: Nil, drop) :: rest =>
         val empty = value match {
           case NULL                     => true
           case coll: util.Collection[_] => coll.isEmpty
@@ -40,6 +42,9 @@ object SimplifyPropertySetters extends GremlinRewriter {
         } else {
           PropertyV(key, value) :: rest
         }
+      case ChooseT(_, prop @ PropertyT(_, Project(_*) :: valueTail) :: Nil, _) :: rest
+          if valueTail.init.forall(_.isInstanceOf[By]) && valueTail.last.isInstanceOf[SelectC] =>
+        prop ++ rest
     }))(steps)
   }
 }

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/walker/NodeUtils.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/walker/NodeUtils.scala
@@ -60,7 +60,7 @@ object NodeUtils {
       case ListLiteral(expressions) =>
         traversalValueToJava(expressions, context, parameterHandler)
       case MapExpression(items) =>
-        asDetachedVertex(items, context)
+        traversalValueToJava(items.toMap, context, parameterHandler)
       case FunctionInvocation(_, _, _, Seq(args)) =>
         expressionValue(args, context)
       case seq: Seq[_] =>
@@ -72,20 +72,6 @@ object NodeUtils {
       case _ =>
         context.unsupported("value expression", value)
     }
-  }
-
-  private def asDetachedVertex[T, P](
-      items: Seq[(PropertyKeyName, Expression)],
-      context: StatementContext[T, P]): AnyRef = {
-    val builder = DetachedVertexProperty.build().setId(0)
-
-    items.foreach(item => {
-      val (PropertyKeyName(name), expression) = item
-      val value = expressionValue(expression, context)
-      builder.addProperty(new DetachedProperty[AnyRef](name, value))
-    })
-
-    builder.create()
   }
 
   def getPathTraversalAliases(patternElement: PatternElement): Vector[String] = {

--- a/translation/src/test/java/org/opencypher/gremlin/translation/helpers/CypherAstHelpers.java
+++ b/translation/src/test/java/org/opencypher/gremlin/translation/helpers/CypherAstHelpers.java
@@ -165,6 +165,10 @@ public final class CypherAstHelpers {
             return start().property(key, traversal);
         }
 
+        public static GremlinSteps<String, GroovyPredicate> property(String key, Object value) {
+            return start().property(key, value);
+        }
+
         public static GremlinSteps<String, GroovyPredicate> sideEffect(GremlinSteps<String, GroovyPredicate> sideEffectTraversal) {
             return start().sideEffect(sideEffectTraversal);
         }

--- a/translation/src/test/java/org/opencypher/gremlin/translation/ir/rewrite/GroupStepFiltersTest.java
+++ b/translation/src/test/java/org/opencypher/gremlin/translation/ir/rewrite/GroupStepFiltersTest.java
@@ -15,7 +15,6 @@
  */
 package org.opencypher.gremlin.translation.ir.rewrite;
 
-import static org.opencypher.gremlin.translation.Tokens.NULL;
 import static org.opencypher.gremlin.translation.Tokens.START;
 import static org.opencypher.gremlin.translation.Tokens.UNUSED;
 import static org.opencypher.gremlin.translation.helpers.CypherAstAssertions.assertThat;
@@ -163,11 +162,7 @@ public class GroupStepFiltersTest {
             .hasTraversal(
                 __.inject(START).coalesce(
                     __.start().V().as("n").hasLabel("N").has("p", P.eq("n")),
-                    __.start().addV("N").as("n").choose(
-                        __.constant("n").is(P.neq(NULL)).unfold(),
-                        __.property("p", __.constant("n")),
-                        __.sideEffect(__.properties("p").drop())
-                    )
+                    __.start().addV("N").as("n").property("p", __.constant("n"))
                 ).as("n").barrier().limit(0)
             );
     }

--- a/translation/src/test/java/org/opencypher/gremlin/translation/ir/rewrite/SimplifyPropertySettersTest.java
+++ b/translation/src/test/java/org/opencypher/gremlin/translation/ir/rewrite/SimplifyPropertySettersTest.java
@@ -15,6 +15,7 @@
  */
 package org.opencypher.gremlin.translation.ir.rewrite;
 
+import static java.util.Collections.emptyMap;
 import static org.opencypher.gremlin.translation.Tokens.NULL;
 import static org.opencypher.gremlin.translation.helpers.CypherAstAssertions.assertThat;
 import static org.opencypher.gremlin.translation.helpers.CypherAstHelpers.P;
@@ -38,7 +39,7 @@ public class SimplifyPropertySettersTest {
     );
 
     @Test
-    public void create() {
+    public void createProperties() {
         assertThat(parse(
             "CREATE ({foo: 'bar', baz: null, quux: $x})"
         ))
@@ -52,37 +53,37 @@ public class SimplifyPropertySettersTest {
     }
 
     @Test
-    public void unset() {
+    public void setProperties() {
         assertThat(parse(
             "MATCH (n) " +
-                "SET n.foo = []"
+                "SET " +
+                "n.p1 = []," +
+                "n.p2 = [1]," +
+                "n.p3 = {}," +
+                "n.p4 = {k:1}"
         ))
             .withFlavor(flavor)
             .hasTraversalBeforeReturn(
                 __.V().as("n")
                     .select("n")
-                    .choose(P.neq(NULL),
-                        __.sideEffect(__.properties("foo").drop()),
+                    .choose(
+                        P.neq(NULL),
+                        __.sideEffect(__.properties("p1").drop()),
                         __.constant(NULL))
-                    .barrier().limit(0)
-            );
-    }
-
-    @Test
-    public void setList() {
-        assertThat(parse(
-            "MATCH (n) " +
-                "SET n.foo = [1]"
-        ))
-            .withFlavor(flavor)
-            .hasTraversalBeforeReturn(
-                __.V().as("n")
                     .select("n")
-                    .choose(P.neq(NULL),
-                        __.property("foo",
-                            __.project("  GENERATED1")
-                                .by(__.constant(1))
-                                .select(Column.values)),
+                    .choose(
+                        P.neq(NULL),
+                        __.property("p2", __.project("  GENERATED1").by(__.constant(1)).select(Column.values)),
+                        __.constant(NULL))
+                    .select("n")
+                    .choose(
+                        P.neq(NULL),
+                        __.property("p3", emptyMap()),
+                        __.constant(NULL))
+                    .select("n")
+                    .choose(
+                        P.neq(NULL),
+                        __.property("p4", __.project("k").by(__.constant(1))),
                         __.constant(NULL))
                     .barrier().limit(0)
             );

--- a/translation/src/test/java/org/opencypher/gremlin/translation/ir/rewrite/SimplifyPropertySettersTest.java
+++ b/translation/src/test/java/org/opencypher/gremlin/translation/ir/rewrite/SimplifyPropertySettersTest.java
@@ -23,6 +23,7 @@ import static org.opencypher.gremlin.translation.helpers.CypherAstHelpers.parame
 import static org.opencypher.gremlin.translation.helpers.CypherAstHelpers.parse;
 import static org.opencypher.gremlin.translation.helpers.ScalaHelpers.seq;
 
+import org.apache.tinkerpop.gremlin.structure.Column;
 import org.junit.Test;
 import org.opencypher.gremlin.translation.translator.TranslatorFlavor;
 
@@ -62,6 +63,26 @@ public class SimplifyPropertySettersTest {
                     .select("n")
                     .choose(P.neq(NULL),
                         __.sideEffect(__.properties("foo").drop()),
+                        __.constant(NULL))
+                    .barrier().limit(0)
+            );
+    }
+
+    @Test
+    public void setList() {
+        assertThat(parse(
+            "MATCH (n) " +
+                "SET n.foo = [1]"
+        ))
+            .withFlavor(flavor)
+            .hasTraversalBeforeReturn(
+                __.V().as("n")
+                    .select("n")
+                    .choose(P.neq(NULL),
+                        __.property("foo",
+                            __.project("  GENERATED1")
+                                .by(__.constant(1))
+                                .select(Column.values)),
                         __.constant(NULL))
                     .barrier().limit(0)
             );


### PR DESCRIPTION
Experimental implementation of list and map literals as Gremlin projections.

- Allows to translate every individual collection item as an expression.
- Empty maps are inlined as instances of `LinkedHashMap`.
- Includes a related change to `DELETE` translation that now delegates to `ExpressionWalker` (TCK tests for `DELETE` depend on this collection translation).

Let's give this some thought before actually merging.

+19 TCK