### PR TITLE
Run SemanticAnalysis before&after Normalization

### DIFF
--- a/translation/src/main/scala/org/opencypher/gremlin/translation/CypherAst.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/CypherAst.scala
@@ -25,7 +25,7 @@ import org.opencypher.gremlin.translation.translator.Translator
 import org.opencypher.gremlin.translation.walker.StatementWalker
 import org.opencypher.v9_0.ast._
 import org.opencypher.v9_0.expressions._
-import org.opencypher.v9_0.frontend.phases.{BaseState, CompilationPhases, InitialState}
+import org.opencypher.v9_0.frontend.phases._
 import org.opencypher.v9_0.rewriting.RewriterStepSequencer
 import org.opencypher.v9_0.rewriting.rewriters.Never
 import org.opencypher.v9_0.util.symbols.{AnyType, CypherType}
@@ -140,6 +140,7 @@ object CypherAst {
     val state = CompilationPhases
       .parsing(RewriterStepSequencer.newPlain, Never)
       .andThen(Normalization)
+      .andThen(SemanticAnalysis(warn = false))
       .transform(startState, EmptyParserContext(preParsedQueryText, Some(offset)))
 
     val params = parameters ++ state.extractedParams()

--- a/translation/src/test/java/org/opencypher/gremlin/translation/ir/rewrite/GroupStepFiltersTest.java
+++ b/translation/src/test/java/org/opencypher/gremlin/translation/ir/rewrite/GroupStepFiltersTest.java
@@ -155,4 +155,15 @@ public class GroupStepFiltersTest {
 
     }
 
+    @Test
+    public void unnamedVariables() {
+        assertThat(parse(
+            "MATCH (:person {name: 'marko'})-[r:knows]->(:person {name: 'josh'}) RETURN r"
+        ))
+            .withFlavor(flavor)
+            .rewritingWith(GroupStepFilters$.MODULE$)
+            .adds(__().V().as("  UNNAMED7").hasLabel("person").has("name", P.isEq("marko")))
+            .adds(__().inV().as("  UNNAMED44").hasLabel("person").has("name", P.isEq("josh")));
+    }
+
 }


### PR DESCRIPTION
- Variables created in `nameAllPatternElements` and other rewriters should appear in `state.semantics().typeTable`
- As in `frontend.phases.CompilationPhases`, `SemanticAnalysis` should run twice

Signed-off-by: Dwitry <dwitry@users.noreply.github.com>