### PR TITLE
Support alias reuse in WHERE patterns

### DIFF
--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/WhereTest.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/WhereTest.java
@@ -158,6 +158,19 @@ public class WhereTest {
             .containsExactlyInAnyOrder("marko", "josh", "peter");
     }
 
+    @Test
+    public void reversePattern() {
+        List<Map<String, Object>> results = submitAndGet(
+            "MATCH (n:person) " +
+                "WHERE (:software)<-[:created]-(n) " +
+                "RETURN n.name"
+        );
+
+        assertThat(results)
+            .extracting("n.name")
+            .containsExactlyInAnyOrder("marko", "josh", "peter");
+    }
+
     /**
      * Custom predicate deserialization is not implemented
      */

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/RemoveUselessSteps.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/RemoveUselessSteps.scala
@@ -25,31 +25,27 @@ import org.opencypher.gremlin.translation.ir.model._
   */
 object RemoveUselessSteps extends GremlinRewriter {
   override def apply(steps: Seq[GremlinStep]): Seq[GremlinStep] = {
-    mapTraversals({
-      firstPass _
-      secondPass
-    })(steps)
+    mapTraversals(
+      firstPass
+        .andThen(secondPass)
+    )(steps)
   }
 
-  private def firstPass(steps: Seq[GremlinStep]): Seq[GremlinStep] = {
-    replace({
-      // Remove `fold` and `unfold` pairs, since the former is an inverse of the latter.
-      case Fold :: Unfold :: rest =>
-        rest
-      case Unfold :: Fold :: rest =>
-        rest
+  private val firstPass: Seq[GremlinStep] => Seq[GremlinStep] = replace({
+    // Remove `fold` and `unfold` pairs, since the former is an inverse of the latter.
+    case Fold :: Unfold :: rest =>
+      rest
+    case Unfold :: Fold :: rest =>
+      rest
 
-      // Remove unused projections
-      case Project(projectKey) :: By(Identity :: Nil, None) :: SelectK(selectKey) :: rest if projectKey == selectKey =>
-        rest
-    })(steps)
-  }
+    // Remove unused projections
+    case Project(projectKey) :: By(Identity :: Nil, None) :: SelectK(selectKey) :: rest if projectKey == selectKey =>
+      rest
+  })
 
-  private def secondPass(steps: Seq[GremlinStep]): Seq[GremlinStep] = {
-    replace({
-      // Remove duplicate `as` steps
-      case As(stepLabel1) :: As(stepLabel2) :: rest if stepLabel1 == stepLabel2 =>
-        As(stepLabel1) :: rest
-    })(steps)
-  }
+  private val secondPass: Seq[GremlinStep] => Seq[GremlinStep] = replace({
+    // Remove duplicate `as` steps
+    case As(stepLabel1) :: As(stepLabel2) :: rest if stepLabel1 == stepLabel2 =>
+      As(stepLabel1) :: rest
+  })
 }

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/SimplifyRenamedAliases.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/SimplifyRenamedAliases.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2018 "Neo4j, Inc." [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opencypher.gremlin.translation.ir.rewrite
+
+import org.opencypher.gremlin.translation.Tokens.NULL
+import org.opencypher.gremlin.translation.ir.TraversalHelper._
+import org.opencypher.gremlin.translation.ir.model._
+
+/**
+  * Match patterns that start with renaming an existing alias
+  * can simply select the existing alias from the traversal.
+  */
+object SimplifyRenamedAliases extends GremlinRewriter {
+
+  override def apply(steps: Seq[GremlinStep]): Seq[GremlinStep] = {
+    mapTraversals(replace({
+      case Vertex :: As(asLabel) :: WhereT(SelectK(selectLabel) :: WhereP(Eq(eqLabel: String)) :: Nil) :: rest
+          if asLabel == selectLabel =>
+        SelectK(eqLabel) :: Is(Neq(NULL)) :: rest
+    }))(steps)
+  }
+}

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/translator/TranslatorFlavor.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/translator/TranslatorFlavor.scala
@@ -40,6 +40,7 @@ object TranslatorFlavor {
     rewriters = Seq(
       InlineMapTraversal,
       SimplifyPropertySetters,
+      SimplifyRenamedAliases,
       GroupStepFilters,
       SimplifySingleProjections,
       RemoveImmediateReselect,

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/walker/ExpressionWalker.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/walker/ExpressionWalker.scala
@@ -417,9 +417,7 @@ private class ExpressionWalker[T, P](context: StatementContext[T, P], g: Gremlin
     }
 
     val name = contextWhere.generateName()
-    g.sideEffect(
-      select.aggregate(name)
-    )
+    g.sideEffect(select.aggregate(name)).barrier()
 
     name
   }

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/walker/ExpressionWalker.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/walker/ExpressionWalker.scala
@@ -409,7 +409,7 @@ private class ExpressionWalker[T, P](context: StatementContext[T, P], g: Gremlin
       projection: Expression): String = {
     val select = __
     val contextWhere = context.copy()
-    PatternWalker.walkExpression(contextWhere, select, relationshipChain)
+    PatternWalker.walk(contextWhere, select, relationshipChain)
     maybePredicate.foreach(WhereWalker.walk(contextWhere, select, _))
 
     if (projection.isInstanceOf[PathExpression]) {

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/walker/MatchWalker.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/walker/MatchWalker.scala
@@ -15,7 +15,7 @@
  */
 package org.opencypher.gremlin.translation.walker
 
-import org.opencypher.gremlin.translation.Tokens.NULL
+import org.opencypher.gremlin.translation.Tokens._
 import org.opencypher.gremlin.translation._
 import org.opencypher.gremlin.translation.context.StatementContext
 import org.opencypher.gremlin.translation.walker.NodeUtils._
@@ -72,21 +72,14 @@ private class MatchWalker[T, P](context: StatementContext[T, P], g: GremlinSteps
   def walkPatternParts(patternParts: Seq[PatternPart], whereOption: Option[Where]): Unit = {
     patternParts.foreach {
       case EveryPath(patternElement) =>
-        foldPatternElement(None, patternElement)
+        PatternWalker.walk(context, g, patternElement)
       case NamedPatternPart(Variable(pathName), EveryPath(patternElement)) =>
-        foldPatternElement(Some(pathName), patternElement)
+        PatternWalker.walk(context, g, patternElement, Some(pathName))
         g.path().as(pathName)
       case n =>
         context.unsupported("match pattern", n)
     }
 
     whereOption.foreach(WhereWalker.walk(context, g, _))
-  }
-
-  private def foldPatternElement(maybeName: Option[String], patternElement: PatternElement): Unit = {
-    context.markFirstStatement()
-    g.V()
-
-    PatternWalker.walkMatch(context, g, patternElement, maybeName)
   }
 }

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/walker/ProjectionWalker.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/walker/ProjectionWalker.scala
@@ -104,10 +104,9 @@ private class ProjectionWalker[T, P](context: StatementContext[T, P], g: Gremlin
     for (item <- items) {
       val AliasedReturnItem(expression, Variable(alias)) = item
 
-      val (_, traversalUnfold) = pivot(alias, expression, finalize)
       val (returnType, traversal) = pivot(alias, expression, finalize)
 
-      allCollector.put(alias, traversalUnfold)
+      allCollector.put(alias, traversal)
 
       returnType match {
         case Pivot       => pivotCollector.put(alias, traversal)

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/walker/WhereWalker.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/walker/WhereWalker.scala
@@ -149,7 +149,7 @@ private class WhereWalker[T, P](context: StatementContext[T, P], g: GremlinSteps
 
       case PatternExpression(RelationshipsPattern(relationshipChain)) =>
         val traversal = g.start()
-        PatternWalker.walkExpression(context, traversal, relationshipChain)
+        PatternWalker.walk(context, traversal, relationshipChain)
         traversal
 
       case l: Literal =>

--- a/translation/src/test/java/org/opencypher/gremlin/translation/ir/rewrite/SimplifyRenamedAliases.java
+++ b/translation/src/test/java/org/opencypher/gremlin/translation/ir/rewrite/SimplifyRenamedAliases.java
@@ -16,6 +16,7 @@
 package org.opencypher.gremlin.translation.ir.rewrite;
 
 import static org.opencypher.gremlin.translation.CypherAstWrapper.parse;
+import static org.opencypher.gremlin.translation.Tokens.NULL;
 import static org.opencypher.gremlin.translation.helpers.CypherAstAssert.P;
 import static org.opencypher.gremlin.translation.helpers.CypherAstAssert.__;
 import static org.opencypher.gremlin.translation.helpers.CypherAstAssertions.assertThat;
@@ -43,6 +44,6 @@ public class SimplifyRenamedAliases {
             .withFlavor(flavor)
             .rewritingWith(SimplifyRenamedAliases$.MODULE$)
             .removes(__().V().as("  GENERATED1").where(__().select("  GENERATED1").where(P.isEq("n"))).outE())
-            .adds(__().select("n").outE());
+            .adds(__().select("n").is(P.neq(NULL)).outE());
     }
 }

--- a/translation/src/test/java/org/opencypher/gremlin/translation/ir/rewrite/SimplifyRenamedAliases.java
+++ b/translation/src/test/java/org/opencypher/gremlin/translation/ir/rewrite/SimplifyRenamedAliases.java
@@ -44,6 +44,19 @@ public class SimplifyRenamedAliases {
             .withFlavor(flavor)
             .rewritingWith(SimplifyRenamedAliases$.MODULE$)
             .removes(__().V().as("  GENERATED1").where(__().select("  GENERATED1").where(P.isEq("n"))).outE())
-            .adds(__().select("n").is(P.neq(NULL)).outE());
+            .adds(__().select("n").outE());
+    }
+
+    @Test
+    public void whereNonStartMatchPattern() {
+        assertThat(parse(
+            "MATCH (n)-->(m) " +
+                "WHERE (m)-->(:L) " +
+                "RETURN m"
+        ))
+            .withFlavor(flavor)
+            .rewritingWith(SimplifyRenamedAliases$.MODULE$)
+            .removes(__().V().as("  GENERATED1").where(__().select("  GENERATED1").where(P.isEq("m"))).outE())
+            .adds(__().select("m").is(P.neq(NULL)).outE());
     }
 }

--- a/translation/src/test/java/org/opencypher/gremlin/translation/ir/rewrite/SimplifyRenamedAliases.java
+++ b/translation/src/test/java/org/opencypher/gremlin/translation/ir/rewrite/SimplifyRenamedAliases.java
@@ -43,8 +43,14 @@ public class SimplifyRenamedAliases {
         ))
             .withFlavor(flavor)
             .rewritingWith(SimplifyRenamedAliases$.MODULE$)
-            .removes(__().V().as("  GENERATED1").where(__().select("  GENERATED1").where(P.isEq("n"))).outE())
-            .adds(__().select("n").outE());
+            .removes(
+                __().V().as("  GENERATED1")
+                    .where(__().select("  GENERATED1").where(P.isEq("n")))
+                    .as("  cypher.path.start.GENERATED2"))
+            .adds(
+                __().select("n")
+                    .as("  cypher.path.start.GENERATED2")
+            );
     }
 
     @Test
@@ -56,7 +62,12 @@ public class SimplifyRenamedAliases {
         ))
             .withFlavor(flavor)
             .rewritingWith(SimplifyRenamedAliases$.MODULE$)
-            .removes(__().V().as("  GENERATED1").where(__().select("  GENERATED1").where(P.isEq("m"))).outE())
-            .adds(__().select("m").is(P.neq(NULL)).outE());
+            .removes(
+                __().V().as("  GENERATED2")
+                    .where(__().select("  GENERATED2").where(P.isEq("m")))
+                    .as("  cypher.path.start.GENERATED3"))
+            .adds(
+                __().select("m").is(P.neq(NULL))
+                    .as("  cypher.path.start.GENERATED3"));
     }
 }


### PR DESCRIPTION
- Covers cases like `WHERE (:L)--(n)`
- Adds rewrite rule to simplify alias renames in the beginning of match patterns to `.select()`
- Adds rewrite rule for accidental `.as(x).as(x)`