### PR TITLE
Return original value if cannot be normalized as integer

### DIFF
--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/CastTest.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/CastTest.java
@@ -83,6 +83,7 @@ public class CastTest {
     public void castToInteger() throws Exception {
         List<Map<String, Object>> results = Stream.of(
             "13",
+            "9007199254740993", // Cannot be stored as Double
             "3.14",
             "'13'",
             "'3.14'",
@@ -99,6 +100,7 @@ public class CastTest {
             .extracting("r")
             .containsExactly(
                 13L,
+                9007199254740993L,
                 3L,
                 13L,
                 3L,

--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/traversal/ReturnNormalizerTest.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/traversal/ReturnNormalizerTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2018 "Neo4j, Inc." [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opencypher.gremlin.traversal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.opencypher.gremlin.translation.ReturnProperties.ID;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.tinkerpop.gremlin.structure.T;
+import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph;
+import org.junit.Before;
+import org.junit.Test;
+import org.opencypher.gremlin.client.CypherGremlinClient;
+
+public class ReturnNormalizerTest {
+
+    private TinkerGraph graph;
+    private CypherGremlinClient client;
+
+    @Before
+    public void setUp() {
+        graph = TinkerGraph.open();
+        client = CypherGremlinClient.inMemory(graph.traversal());
+    }
+
+    @Test
+    public void returnElementWithStringId() {
+        String id = "stringId";
+        graph.addVertex(T.id, id);
+        List<Map<String, Object>> results = client.submit("MATCH (n) RETURN n").all();
+
+        assertThat(results)
+            .extracting("n")
+            .extracting(ID)
+            .containsExactly(id);
+    }
+
+    @Test
+    public void returnStringId() {
+        String id = "stringId";
+        graph.addVertex(T.id, id);
+        List<Map<String, Object>> results = client.submit("MATCH (n) RETURN id(n) AS id").all();
+
+        assertThat(results)
+            .extracting("id")
+            .containsExactly(id);
+    }
+}

--- a/translation/src/main/java/org/opencypher/gremlin/traversal/CustomFunction.java
+++ b/translation/src/main/java/org/opencypher/gremlin/traversal/CustomFunction.java
@@ -129,9 +129,9 @@ public class CustomFunction implements Function<Traverser, Object> {
             });
     }
 
-    public static CustomFunction convertToIntegerType() {
+    public static CustomFunction convertToInteger() {
         return new CustomFunction(
-            "convertToIntegerType",
+            "convertToInteger",
             traverser -> {
                 Object arg = tokenToNull(traverser.get());
                 boolean valid = arg == null ||
@@ -142,9 +142,21 @@ public class CustomFunction implements Function<Traverser, Object> {
                     throw new TypeException("Cannot convert " + className + " to integer");
                 }
 
-                // long in org.neo4j.driver.internal.value.IntegerValue#val
-                Long integer = convertToLong(arg);
-                return nullToToken(integer);
+                return nullToToken(
+                    Optional.ofNullable(arg)
+                        .map(String::valueOf)
+                        .map(v -> {
+                            try {
+                                return Long.valueOf(v);
+                            } catch (NumberFormatException e1) {
+                                try {
+                                    return Double.valueOf(v).longValue();
+                                } catch (NumberFormatException e2) {
+                                    return null;
+                                }
+                            }
+                        })
+                        .orElse(null));
             });
     }
 
@@ -475,20 +487,6 @@ public class CustomFunction implements Function<Traverser, Object> {
                 }
             }
         );
-    }
-
-    static Long convertToLong(Object arg) {
-        return Optional.ofNullable(arg)
-            .map(String::valueOf)
-            .map(v -> {
-                try {
-                    return Double.valueOf(v);
-                } catch (NumberFormatException e) {
-                    return null;
-                }
-            })
-            .map(Double::longValue)
-            .orElse(null);
     }
 
     private static Object flatten(Object element) {

--- a/translation/src/main/java/org/opencypher/gremlin/traversal/ReturnNormalizer.java
+++ b/translation/src/main/java/org/opencypher/gremlin/traversal/ReturnNormalizer.java
@@ -104,7 +104,7 @@ public final class ReturnNormalizer {
         } else if (type instanceof PathType) {
             return normalizePath((Map<?, ?>) value);
         } else if (type instanceof IntegerType) {
-            return CustomFunction.convertToLong(value);
+            return normalizeInteger(value);
         } else if (type instanceof ListType) {
             CypherType cypherType = ((ListType) type).innerType();
             return ((Collection<?>) value)
@@ -200,6 +200,19 @@ public final class ReturnNormalizer {
         return value.stream()
             .map(this::normalizeValue)
             .collect(Collectors.toList());
+    }
+
+    private Object normalizeInteger(Object value) {
+        String s = String.valueOf(value);
+        try {
+            return Long.valueOf(s);
+        } catch (NumberFormatException e1) {
+            try {
+                return Double.valueOf(s).longValue();
+            } catch (NumberFormatException e2) {
+                return value;
+            }
+        }
     }
 
     private Object elementPropertyMap(Element element) {

--- a/translation/src/main/java/org/opencypher/gremlin/traversal/ReturnNormalizer.java
+++ b/translation/src/main/java/org/opencypher/gremlin/traversal/ReturnNormalizer.java
@@ -203,15 +203,10 @@ public final class ReturnNormalizer {
     }
 
     private Object normalizeInteger(Object value) {
-        String s = String.valueOf(value);
-        try {
-            return Long.valueOf(s);
-        } catch (NumberFormatException e1) {
-            try {
-                return Double.valueOf(s).longValue();
-            } catch (NumberFormatException e2) {
-                return value;
-            }
+        if (value instanceof Number) {
+            return ((Number) value).longValue();
+        } else {
+            return value;
         }
     }
 

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/walker/ExpressionWalker.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/walker/ExpressionWalker.scala
@@ -222,7 +222,7 @@ private class ExpressionWalker[T, P](context: WalkerContext[T, P], g: GremlinSte
           case "type"          => traversals.head.map(notNull(__.label().is(p.neq(Vertex.DEFAULT_LABEL)), context))
           case "toboolean"     => traversals.head.map(CustomFunction.convertToBoolean())
           case "tofloat"       => traversals.head.map(CustomFunction.convertToFloat())
-          case "tointeger"     => traversals.head.map(CustomFunction.convertToIntegerType())
+          case "tointeger"     => traversals.head.map(CustomFunction.convertToInteger())
           case "tostring"      => traversals.head.map(CustomFunction.convertToString())
           case _ =>
             throw new SyntaxException(s"Unknown function '$fnName'")


### PR DESCRIPTION
- Integer typecasts now try converting to long first, before converting to double's long value
- If a returned value is typed as integer, but is not numeric, it is now returned as is