### PR TITLE
Lift traversal out of folding projections

### DIFF
--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/ReturnTest.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/ReturnTest.java
@@ -266,17 +266,6 @@ public class ReturnTest {
     }
 
     @Test
-    public void sumRelationshipProperty() throws Exception {
-        List<Map<String, Object>> results = submitAndGet(
-            "MATCH ()-[r:created]->() RETURN count(r) AS count"
-        );
-
-        assertThat(results)
-            .extracting("count")
-            .containsExactly(4L);
-    }
-
-    @Test
     public void labelPredicate() {
         List<Map<String, Object>> results = submitAndGet(
             "MATCH (n) " +

--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/ReturnTest.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/ReturnTest.java
@@ -266,6 +266,17 @@ public class ReturnTest {
     }
 
     @Test
+    public void sumRelationshipProperty() throws Exception {
+        List<Map<String, Object>> results = submitAndGet(
+            "MATCH ()-[r:created]->() RETURN count(r) AS count"
+        );
+
+        assertThat(results)
+            .extracting("count")
+            .containsExactly(4L);
+    }
+
+    @Test
     public void labelPredicate() {
         List<Map<String, Object>> results = submitAndGet(
             "MATCH (n) " +

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/RemoveUnusedAliases.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/RemoveUnusedAliases.scala
@@ -48,8 +48,8 @@ object RemoveUnusedAliases extends GremlinRewriter {
 
     mapTraversals(traversal =>
       traversal.flatMap {
-        case As(stepLabel) if !selected.contains(stepLabel) => Nil
-        case s                                              => Seq(s)
+        case As(stepLabel) if !selected.contains(stepLabel) => None
+        case s                                              => Some(s)
     })(steps)
   }
 

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/RemoveUnusedAliases.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/RemoveUnusedAliases.scala
@@ -46,12 +46,11 @@ object RemoveUnusedAliases extends GremlinRewriter {
       })(localSteps).flatten
     })(steps)
 
-    mapTraversals(
-      replace({
-        case before :: As(stepLabel) :: after if !selected.contains(stepLabel) =>
-          before :: after
-      })
-    )(steps)
+    mapTraversals(traversal =>
+      traversal.flatMap {
+        case As(stepLabel) if !selected.contains(stepLabel) => Nil
+        case s                                              => Seq(s)
+    })(steps)
   }
 
   def predicateAliases(predicate: GremlinPredicate): Seq[String] = {

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/RemoveUnusedAliases.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/RemoveUnusedAliases.scala
@@ -31,14 +31,6 @@ import scala.collection.SortedMap
   */
 object RemoveUnusedAliases extends GremlinRewriter {
   override def apply(steps: Seq[GremlinStep]): Seq[GremlinStep] = {
-    splitAfter({
-      case MapT(Project(_*) :: _) => true
-      case _                      => false
-    })(steps)
-      .flatMap(rewriteSegment)
-  }
-
-  private def rewriteSegment(steps: Seq[GremlinStep]): Seq[GremlinStep] = {
     val selected = foldTraversals(SortedMap.empty[String, Int])((acc, localSteps) => {
       def increment(keys: String*): SortedMap[String, Int] = {
         keys.foldLeft(acc)((acc, key) => acc.updated(key, acc.getOrElse(key, 0) + 1))
@@ -54,12 +46,11 @@ object RemoveUnusedAliases extends GremlinRewriter {
       })(localSteps).flatten
     })(steps)
 
-    mapTraversals(
-      replace({
-        case before :: As(stepLabel) :: after if !selected.contains(stepLabel) =>
-          before :: after
-      })
-    )(steps)
+    mapTraversals(traversal =>
+      traversal.flatMap {
+        case As(stepLabel) if !selected.contains(stepLabel) => Nil
+        case s                                              => Seq(s)
+    })(steps)
   }
 
   def predicateAliases(predicate: GremlinPredicate): Seq[String] = {

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/RemoveUnusedAliases.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/RemoveUnusedAliases.scala
@@ -46,11 +46,12 @@ object RemoveUnusedAliases extends GremlinRewriter {
       })(localSteps).flatten
     })(steps)
 
-    mapTraversals(traversal =>
-      traversal.flatMap {
-        case As(stepLabel) if !selected.contains(stepLabel) => Nil
-        case s                                              => Seq(s)
-    })(steps)
+    mapTraversals(
+      replace({
+        case before :: As(stepLabel) :: after if !selected.contains(stepLabel) =>
+          before :: after
+      })
+    )(steps)
   }
 
   def predicateAliases(predicate: GremlinPredicate): Seq[String] = {

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/RemoveUselessSteps.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/RemoveUselessSteps.scala
@@ -15,6 +15,7 @@
  */
 package org.opencypher.gremlin.translation.ir.rewrite
 
+import org.opencypher.gremlin.translation.Tokens.NULL
 import org.opencypher.gremlin.translation.ir.TraversalHelper._
 import org.opencypher.gremlin.translation.ir.model._
 
@@ -32,7 +33,7 @@ object RemoveUselessSteps extends GremlinRewriter {
   }
 
   private val firstPass: Seq[GremlinStep] => Seq[GremlinStep] = replace({
-    // Remove `fold` and `unfold` pairs, since the former is an inverse of the latter.
+    // Remove `fold` and `unfold` pairs, since the former is an inverse of the latter
     case Fold :: Unfold :: rest =>
       rest
     case Unfold :: Fold :: rest =>
@@ -44,6 +45,10 @@ object RemoveUselessSteps extends GremlinRewriter {
   })
 
   private val secondPass: Seq[GremlinStep] => Seq[GremlinStep] = replace({
+    // Remove null check immediately after graph step
+    case Vertex :: Is(Neq(NULL)) :: rest =>
+      Vertex :: rest
+
     // Remove duplicate `as` steps
     case As(stepLabel1) :: As(stepLabel2) :: rest if stepLabel1 == stepLabel2 =>
       As(stepLabel1) :: rest

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/walker/NodeUtils.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/walker/NodeUtils.scala
@@ -126,6 +126,11 @@ object NodeUtils {
     g.start().choose(p.neq(NULL), traversal, g.start().constant(NULL))
   }
 
+  def emptyToNull[T, P](traversal: GremlinSteps[T, P], context: WalkerContext[T, P]): GremlinSteps[T, P] = {
+    val g = context.dsl.steps()
+    g.start().choose(traversal, traversal, g.start().constant(NULL))
+  }
+
   def asList[T, P](expressions: Seq[Expression], context: WalkerContext[T, P]): GremlinSteps[T, P] = {
     val g = context.dsl.steps()
     if (expressions.isEmpty) {

--- a/translation/src/test/scala/org/opencypher/gremlin/translation/ir/rewrite/RemoveUnusedAliasesTest.scala
+++ b/translation/src/test/scala/org/opencypher/gremlin/translation/ir/rewrite/RemoveUnusedAliasesTest.scala
@@ -83,4 +83,18 @@ class RemoveUnusedAliasesTest {
       .keeps(__.as("n"))
       .keeps(__.as("m"))
   }
+
+  @Test
+  def adjacentAs(): Unit = {
+    assertThat(parse("""
+         |MATCH ()-[r:R]->()
+         |RETURN r
+       """.stripMargin))
+      .withFlavor(flavor)
+      .rewritingWith(RemoveUnusedAliases)
+      .removes(__.as("  cypher.path.start.GENERATED1"))
+      .removes(__.as("  UNNAMED7"))
+      .removes(__.as("  UNNAMED17"))
+      .keeps(__.as("r"))
+  }
 }

--- a/translation/src/test/scala/org/opencypher/gremlin/translation/ir/rewrite/RemoveUnusedAliasesTest.scala
+++ b/translation/src/test/scala/org/opencypher/gremlin/translation/ir/rewrite/RemoveUnusedAliasesTest.scala
@@ -19,9 +19,16 @@ import org.junit.Test
 import org.opencypher.gremlin.translation.CypherAst.parse
 import org.opencypher.gremlin.translation.ir.helpers.CypherAstAssert.__
 import org.opencypher.gremlin.translation.ir.helpers.CypherAstAssertions.assertThat
-import org.opencypher.gremlin.translation.translator.TranslatorFlavor.empty
+import org.opencypher.gremlin.translation.translator.TranslatorFlavor
 
 class RemoveUnusedAliasesTest {
+
+  val flavor = new TranslatorFlavor(
+    rewriters = Seq(
+      InlineMapTraversal
+    ),
+    postConditions = Nil
+  )
 
   @Test
   def generated(): Unit = {
@@ -29,8 +36,9 @@ class RemoveUnusedAliasesTest {
         |MATCH (n)-->()
         |RETURN n
       """.stripMargin))
-      .withFlavor(empty)
+      .withFlavor(flavor)
       .rewritingWith(RemoveUnusedAliases)
+      .removes(__.as("  cypher.path.start.GENERATED1"))
       .removes(__.as("  UNNAMED10"))
       .removes(__.as("  UNNAMED13"))
       .keeps(__.as("n"))
@@ -42,8 +50,9 @@ class RemoveUnusedAliasesTest {
         |MATCH (n)-[r]->(m)
         |RETURN n
       """.stripMargin))
-      .withFlavor(empty)
+      .withFlavor(flavor)
       .rewritingWith(RemoveUnusedAliases)
+      .removes(__.as("  cypher.path.start.GENERATED1"))
       .removes(__.as("r"))
       .removes(__.as("m"))
       .keeps(__.as("n"))
@@ -52,7 +61,7 @@ class RemoveUnusedAliasesTest {
   @Test
   def fromTo(): Unit = {
     assertThat(parse("CREATE (n)-[:R]->(m)"))
-      .withFlavor(empty)
+      .withFlavor(flavor)
       .rewritingWith(RemoveUnusedAliases)
       .removes(__.as("  UNNAMED11"))
       .keeps(__.as("n"))
@@ -66,8 +75,9 @@ class RemoveUnusedAliasesTest {
         |MATCH (m)-->(k)
         |RETURN n
       """.stripMargin))
-      .withFlavor(empty)
+      .withFlavor(flavor)
       .rewritingWith(RemoveUnusedAliases)
+      .removes(__.as("  cypher.path.start.GENERATED1"))
       .removes(__.as("  UNNAMED10"))
       .removes(__.as("  UNNAMED26"))
       .keeps(__.as("n"))


### PR DESCRIPTION
This rewrite lifts traversals from single projections that start with a fold. This helps other rewriters to detect cases like `fold().unfold()`, greatly simplifying some projections.

`coalesce`-based null guards have been replaced with `choose`-based, because of unexpected behavior of global `coalesce` in some TCK corner cases.

Unused alias removal has been fixed to not skip adjacent `as` steps.