### PR TITLE
Remove reliance on projectFreshSortExpressions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,9 @@ subprojects {
 
     repositories {
         mavenCentral()
+        maven {
+            url 'https://jitpack.io'
+        }
     }
 
     sourceCompatibility = 1.8
@@ -332,10 +335,6 @@ project(':testware:tck') {
         from 'build/test-results/tck/TEST-org.opencypher.gremlin.tck.TckTest.xml'
         into 'build/test-results/tck/'
         rename { fileName -> "TckTest-before.xml" }
-    }
-
-    repositories {
-        maven { url "https://jitpack.io" }
     }
 
     dependencies {

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/CypherAst.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/CypherAst.scala
@@ -192,8 +192,8 @@ object CypherAst {
     val startState = InitialState(preParsedQueryText, Some(offset), EmptyPlannerName)
     val state = CompilationPhases
       .parsing(RewriterStepSequencer.newPlain, literalExtraction = Never)
-      .andThen(Normalization)
       .andThen(SemanticAnalysis(warn = false))
+      .andThen(Normalization)
       .transform(startState, EmptyParserContext(preParsedQueryText, Some(offset)))
 
     val statement = state.statement()

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/Normalization.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/Normalization.scala
@@ -21,11 +21,10 @@ import org.opencypher.v9_0.util.{Rewriter, inSequence}
 
 object Normalization extends StatementRewriter {
   override def instance(context: BaseContext): Rewriter = inSequence(
-    collapseMultipleInPredicates,
     flattenBooleanOperators,
     simplifyPredicates,
-    nameUpdatingClauses,
-    projectFreshSortExpressions
+    collapseMultipleInPredicates,
+    nameUpdatingClauses
   )
 
   override def description: String = "normalize the AST"

--- a/translation/src/test/java/org/opencypher/gremlin/translation/AstRewriterTest.java
+++ b/translation/src/test/java/org/opencypher/gremlin/translation/AstRewriterTest.java
@@ -99,7 +99,6 @@ public class AstRewriterTest {
             "MATCH (a:artist) " +
                 "WITH a AS a " +
                 "WITH a AS a, a.age > 18 AS `  FRESHID36`" +
-                "WITH a AS a, `  FRESHID36`AS `  FRESHID36`" +
                 "WHERE `  FRESHID36`" +
                 "WITH a AS a " +
                 "RETURN a.name AS `a.name`"
@@ -117,11 +116,9 @@ public class AstRewriterTest {
             "MATCH (a:artist) " +
                 "WITH a AS a " +
                 "WITH a AS a, a.age > 18 AS `  FRESHID36`" +
-                "WITH a AS a, `  FRESHID36`AS `  FRESHID36`" +
                 "WHERE `  FRESHID36`" +
                 "WITH a AS a " +
                 "WITH a.name AS `  FRESHID50` " +
-                "WITH `  FRESHID50` AS `  FRESHID50` " +
                 "ORDER BY `  FRESHID50` " +
                 "RETURN `  FRESHID50` AS `a.name`"
         );
@@ -136,7 +133,6 @@ public class AstRewriterTest {
         )).normalizedTo(
             "MATCH (a:artist) " +
                 "WITH a.name AS `  FRESHID26` " +
-                "WITH `  FRESHID26` AS `  FRESHID26` " +
                 "ORDER BY `  FRESHID26` " +
                 "RETURN `  FRESHID26` AS `a.name`"
         );
@@ -151,7 +147,6 @@ public class AstRewriterTest {
         )).normalizedTo(
             "MATCH (a:artist)<-[:writtenBy]-(s:song) " +
                 "WITH a.name AS `  FRESHID49`, s.name AS `  FRESHID57` " +
-                "WITH `  FRESHID49` AS `  FRESHID49`, `  FRESHID57` AS `  FRESHID57` " +
                 "ORDER BY `  FRESHID49`, `  FRESHID57` " +
                 "RETURN `  FRESHID49` AS `a.name`, `  FRESHID57` AS `s.name`"
         );
@@ -167,7 +162,6 @@ public class AstRewriterTest {
         )).normalizedTo(
             "MATCH (a:artist) " +
                 "WITH a.name AS `  FRESHID26` " +
-                "WITH `  FRESHID26` AS `  FRESHID26` " +
                 "ORDER BY `  FRESHID26` SKIP 1 LIMIT 2 " +
                 "RETURN `  FRESHID26` AS `a.name`"
         );


### PR DESCRIPTION
These changes remove the `projectFreshSortExpressions` rewriter, which in turn:
- Removes identity projections produced by this rewriter
- Will help to migrate to new FE with changes from https://github.com/opencypher/front-end/pull/21.