### PR TITLE
Use `CustomFunctionsFallback` if  Extensions are not enabled

### DIFF
--- a/translation/src/main/java/org/opencypher/gremlin/translation/translator/Translator.java
+++ b/translation/src/main/java/org/opencypher/gremlin/translation/translator/Translator.java
@@ -31,6 +31,7 @@ import org.opencypher.gremlin.translation.groovy.GroovyGremlinBindings;
 import org.opencypher.gremlin.translation.groovy.GroovyGremlinPredicates;
 import org.opencypher.gremlin.translation.groovy.GroovyGremlinSteps;
 import org.opencypher.gremlin.translation.groovy.GroovyPredicate;
+import org.opencypher.gremlin.translation.ir.rewrite.CustomFunctionFallback;
 import org.opencypher.gremlin.translation.traversal.TraversalGremlinBindings;
 import org.opencypher.gremlin.translation.traversal.TraversalGremlinPredicates;
 import org.opencypher.gremlin.translation.traversal.TraversalGremlinSteps;
@@ -282,8 +283,17 @@ public final class Translator<T, P> {
                 predicates,
                 bindings,
                 features,
-                flavor != null ? flavor : TranslatorFlavor.gremlinServer()
+                getFlavor(flavor, features)
             );
+        }
+
+        private TranslatorFlavor getFlavor(TranslatorFlavor flavor, Set<TranslatorFeature> features) {
+            TranslatorFlavor result = flavor != null ? flavor : TranslatorFlavor.gremlinServer();
+            if (features.contains(TranslatorFeature.CYPHER_EXTENSIONS)) {
+                return result;
+            } else {
+                return result.extend(CustomFunctionFallback.asSeq());
+            }
         }
     }
 

--- a/translation/src/main/java/org/opencypher/gremlin/traversal/CustomFunction.java
+++ b/translation/src/main/java/org/opencypher/gremlin/traversal/CustomFunction.java
@@ -15,6 +15,7 @@
  */
 package org.opencypher.gremlin.traversal;
 
+import java.util.Objects;
 import java.util.function.Function;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 
@@ -124,5 +125,18 @@ public class CustomFunction {
             "cypherException",
             CustomFunctions.cypherException()
         );
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof CustomFunction)) return false;
+        CustomFunction that = (CustomFunction) o;
+        return Objects.equals(name, that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
     }
 }

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/CustomFunctionFallback.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/CustomFunctionFallback.scala
@@ -23,6 +23,8 @@ import org.opencypher.gremlin.translation.ir.model._
   * Replaces Custom Functions with "The Best We Could Do" Gremlin native alternatives
   */
 object CustomFunctionFallback extends GremlinRewriter {
+  val asSeq: Seq[GremlinRewriter] = Seq(CustomFunctionFallback)
+
   override def apply(steps: Seq[GremlinStep]): Seq[GremlinStep] = {
 
     mapTraversals(replace({

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/translator/TranslatorFlavor.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/translator/TranslatorFlavor.scala
@@ -26,6 +26,9 @@ sealed case class TranslatorFlavor private[translation] (
     postConditions: Seq[GremlinPostCondition]) {
   def extend(rewriters: Seq[GremlinRewriter], postConditions: Seq[GremlinPostCondition]): TranslatorFlavor =
     TranslatorFlavor(this.rewriters ++ rewriters, this.postConditions ++ postConditions)
+
+  def extend(rewriters: Seq[GremlinRewriter]): TranslatorFlavor =
+    TranslatorFlavor(this.rewriters ++ rewriters, this.postConditions)
 }
 
 object TranslatorFlavor {
@@ -63,7 +66,6 @@ object TranslatorFlavor {
     */
   val cosmosDb: TranslatorFlavor = gremlinServer.extend(
     rewriters = Seq(
-      CustomFunctionFallback,
       CosmosDbFlavor
     ),
     postConditions = Nil
@@ -74,7 +76,6 @@ object TranslatorFlavor {
     */
   val neptune: TranslatorFlavor = gremlinServer.extend(
     rewriters = Seq(
-      CustomFunctionFallback,
       NeptuneFlavor
     ),
     postConditions = Nil

--- a/translation/src/test/scala/org/opencypher/gremlin/translation/ir/rewrite/CustomFunctionsFallbackTest.scala
+++ b/translation/src/test/scala/org/opencypher/gremlin/translation/ir/rewrite/CustomFunctionsFallbackTest.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2018 "Neo4j, Inc." [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opencypher.gremlin.translation.ir.rewrite
+
+import org.junit.Test
+import org.opencypher.gremlin.translation.CypherAst.parse
+import org.opencypher.gremlin.translation.ir.helpers.CypherAstAssert.__
+import org.opencypher.gremlin.translation.ir.helpers.CypherAstAssertions.assertThat
+import org.opencypher.gremlin.translation.translator.Translator
+import org.opencypher.gremlin.traversal.CustomFunction
+
+class CustomFunctionsFallbackTest {
+
+  @Test
+  def enableCypherExtensions(): Unit = {
+    val translator = Translator.builder.traversal().enableCypherExtensions.build()
+
+    assertThat(parse("MATCH (a) DELETE a"))
+      .withFlavor(translator.flavor())
+      .contains(__.map(CustomFunction.cypherException()))
+  }
+
+  @Test
+  def disableCypherExtensions(): Unit = {
+    val translator = Translator.builder.gremlinGroovy().build()
+
+    assertThat(parse("MATCH (a) DELETE a"))
+      .withFlavor(translator.flavor())
+      .contains(
+        __.bothE()
+          .path()
+          .from("Cannot delete node, because it still has relationships. To delete this node, you must first delete its relationships."))
+  }
+
+}


### PR DESCRIPTION
Always use `CustomFunctionsFallback` if Cypher Extensions are not enable.

Signed-off-by: Dwitry dwitry@users.noreply.github.com