### PR TITLE
Custom functions cypherProperties and cypherSize fallback (#160)

### DIFF
--- a/translation/src/test/java/org/opencypher/gremlin/translation/CypherAstTest.java
+++ b/translation/src/test/java/org/opencypher/gremlin/translation/CypherAstTest.java
@@ -196,11 +196,11 @@ public class CypherAstTest {
             "MATCH (n:N) " +
                 "WITH n.p AS s " +
                 "WHERE s STARTS WITH 'x' AND s ENDS WITH 'x' AND s CONTAINS 'x' " +
-                "RETURN size(s), toString(s)"
+                "RETURN toString(s)"
         );
         Translator<String, GroovyPredicate> translator = Translator.builder().gremlinGroovy().build();
 
         assertThatThrownBy(() -> ast.buildTranslation(translator))
-            .hasMessageContaining("cypherContains, cypherEndsWith, cypherSize, cypherStarsWith, cypherToString");
+            .hasMessageContaining("cypherContains, cypherEndsWith, cypherStarsWith, cypherToString");
     }
 }

--- a/translation/src/test/scala/org/opencypher/gremlin/translation/ir/verify/NoCustomFunctionsTest.scala
+++ b/translation/src/test/scala/org/opencypher/gremlin/translation/ir/verify/NoCustomFunctionsTest.scala
@@ -35,11 +35,11 @@ class NoCustomFunctionsTest {
         |MATCH (n:N)
         |WITH n.p AS s
         |WHERE s STARTS WITH 'x' AND s ENDS WITH 'x' AND s CONTAINS 'x'
-        |RETURN size(s), toString(s)
+        |RETURN toString(s)
     """.stripMargin)
     val translator = Translator.builder.gremlinGroovy.build(flavor)
 
     assertThatThrownBy(() => ast.buildTranslation(translator))
-      .hasMessageContaining("cypherContains, cypherEndsWith, cypherSize, cypherStarsWith, cypherToString")
+      .hasMessageContaining("cypherContains, cypherEndsWith, cypherStarsWith, cypherToString")
   }
 }


### PR DESCRIPTION
- cypherSize - treat input as collection if type information and extensions are not available
- cypherProperties - treat input as element if type information and extensions are not available
- +2 TCK on Native

Signed-off-by: Dwitry dwitry@users.noreply.github.com