### PR TITLE
Support named path creation

### DIFF
--- a/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/GroupStepFilters.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/GroupStepFilters.scala
@@ -38,8 +38,8 @@ object GroupStepFilters extends GremlinRewriter {
 
   private def rewriteSegment(steps: Seq[GremlinStep]): Seq[GremlinStep] = {
     val rewrittenStepLabels = extract({
-      case As(stepLabel) :: _                   => stepLabel
-      case Repeat(_ :: As(stepLabel) :: _) :: _ => stepLabel
+      case prev :: As(stepLabel) :: _ if prev != AddV => stepLabel
+      case Repeat(_ :: As(stepLabel) :: _) :: _       => stepLabel
     })(steps).toSet
 
     if (rewrittenStepLabels.isEmpty) {

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/walker/CreateWalker.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/walker/CreateWalker.scala
@@ -15,9 +15,8 @@
  */
 package org.opencypher.gremlin.translation.walker
 
-import org.apache.tinkerpop.gremlin.structure.VertexProperty.Cardinality
-import org.apache.tinkerpop.gremlin.structure.VertexProperty.Cardinality.single
 import org.opencypher.gremlin.translation.GremlinSteps
+import org.opencypher.gremlin.translation.Tokens.MATCH_START
 import org.opencypher.gremlin.translation.context.WalkerContext
 import org.opencypher.gremlin.translation.exception.SyntaxException
 import org.opencypher.gremlin.translation.walker.NodeUtils.setProperty
@@ -49,6 +48,10 @@ private class CreateWalker[T, P](context: WalkerContext[T, P], g: GremlinSteps[T
     patternParts.foreach {
       case EveryPath(n: PatternElement) =>
         walkPattern(n)
+      case NamedPatternPart(Variable(name), EveryPath(n: PatternElement)) =>
+        walkPattern(n)
+        PatternWalker.walk(context, g, n, Some(name))
+        g.path().from(MATCH_START + name).as(name)
       case n =>
         context.unsupported("create pattern", n)
     }

--- a/translation/src/test/scala/org/opencypher/gremlin/translation/ir/rewrite/GroupStepFiltersTest.scala
+++ b/translation/src/test/scala/org/opencypher/gremlin/translation/ir/rewrite/GroupStepFiltersTest.scala
@@ -15,9 +15,9 @@
  */
 package org.opencypher.gremlin.translation.ir.rewrite
 
+import org.apache.tinkerpop.gremlin.structure.VertexProperty.Cardinality.single
 import org.junit.Test
 import org.opencypher.gremlin.translation.CypherAst.parse
-import org.opencypher.gremlin.translation.Tokens
 import org.opencypher.gremlin.translation.Tokens.UNNAMED
 import org.opencypher.gremlin.translation.ir.helpers.CypherAstAssert.{P, __}
 import org.opencypher.gremlin.translation.ir.helpers.CypherAstAssertions.assertThat
@@ -165,5 +165,13 @@ class GroupStepFiltersTest {
       .rewritingWith(GroupStepFilters)
       .adds(__.V().as(UNNAMED + 7).hasLabel("person").has("name", P.isEq("marko")))
       .adds(__.inV().as(UNNAMED + 44).hasLabel("person").has("name", P.isEq("josh")))
+  }
+
+  @Test
+  def keepAdditions(): Unit = {
+    assertThat(parse("MERGE p = (a {x: 1}) RETURN p"))
+      .withFlavor(flavor)
+      .rewritingWith(GroupStepFilters)
+      .keeps(__.addV().as("a").property(single, "x", __.constant(1)))
   }
 }


### PR DESCRIPTION
- Fix bug with GroupStepFilters rewriter when condition is applied to `addV` step instead of `V` step
- TCK +2

Signed-off-by: Dwitry dwitry@users.noreply.github.com