### PR TITLE
Upgrade to latest FE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         guavaVersion = '22.0'
         junitVersion = '4.12'
         cypherVersion = '9.0'
-        cypherFrontendVersion = '9.0.7'
+        cypherFrontendVersion = '9.0.20180925'
         scalaVersion = '2.11'
         scalaPatchVersion = '12'
         springBootVersion = '1.5.6.RELEASE'

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/RemoveIntermediateProjection.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/RemoveIntermediateProjection.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2018 "Neo4j, Inc." [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opencypher.gremlin.translation.ir.rewrite
+
+import org.opencypher.gremlin.translation.ir.TraversalHelper._
+import org.opencypher.gremlin.translation.ir.model._
+
+/**
+  * This rule removes intermediate projection in case it does not have any logic, and followed by final projection
+  */
+object RemoveIntermediateProjection extends GremlinRewriter {
+
+  override def apply(steps: Seq[GremlinStep]): Seq[GremlinStep] = {
+    val traversals = split(BeforeStep, {
+      case Project(_*) => true
+      case _           => false
+    })(steps)
+
+    val size = traversals.size
+    if (size < 3) {
+      return steps
+    }
+
+    val intermediateProjection = traversals(size - 2)
+    val finalizationProjection = traversals.last
+
+    if (finalizationProjection.size == intermediateProjection.size
+        && finalizationProjection.head == intermediateProjection.head
+        && onlyContainsIdentityOrSelect(intermediateProjection)) {
+
+      val replacements = getReplacements(intermediateProjection)
+      val singleProjection = replaceInBy(finalizationProjection, replacements)
+
+      (traversals.take(size - 2) :+ singleProjection).flatten
+    } else {
+      steps
+    }
+  }
+
+  def onlyContainsIdentityOrSelect(steps: Seq[GremlinStep]): Boolean = !steps.exists {
+    case Project(_*)                 => false
+    case By(Identity :: Nil, None)   => false
+    case By(SelectK(_) :: Nil, None) => false
+    case _                           => true
+  }
+
+  def getReplacements(intermediateProjection: Seq[GremlinStep]): Map[GremlinStep, GremlinStep] = {
+    val Project(keys @ _*) = intermediateProjection.head
+    val valueSteps = intermediateProjection.tail.map {
+      case By(Identity :: Nil, None)     => Identity
+      case By(SelectK(key) :: Nil, None) => SelectK(key)
+    }
+
+    val keySteps = keys.map(key => SelectK(key))
+
+    (keySteps zip valueSteps).toMap
+  }
+
+  def replaceInBy(projection: Seq[GremlinStep], replace: Map[GremlinStep, GremlinStep]): Seq[GremlinStep] =
+    projection.map {
+      case By(steps, order) => By(replace(steps.head) +: steps.tail, order)
+      case s                => s
+    }
+
+}

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/translator/TranslatorFlavor.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/translator/TranslatorFlavor.scala
@@ -47,6 +47,7 @@ object TranslatorFlavor {
       SimplifyRenamedAliases,
       RemoveMultipleAliases,
       GroupStepFilters,
+      RemoveIntermediateProjection,
       SimplifySingleProjections,
       RemoveUselessNullChecks,
       RemoveIdentityReselect,

--- a/translation/src/test/java/org/opencypher/gremlin/translation/AstRewriterTest.java
+++ b/translation/src/test/java/org/opencypher/gremlin/translation/AstRewriterTest.java
@@ -104,7 +104,7 @@ public class AstRewriterTest {
     }
 
     @Test
-    public void matchWhereOrderBy() throws Exception {
+    public void dontRewriteMatchWhereOrderBy() throws Exception {
         assertThat(parse(
             "MATCH (a:artist) " +
                 "WITH a WHERE a.age > 18 " +
@@ -112,44 +112,40 @@ public class AstRewriterTest {
                 "ORDER BY a.name"
         )).normalizedTo(
             "MATCH (a:artist) " +
-                "WITH a AS a " +
-                "WHERE a.age > 18 " +
-                "WITH a.name AS `  FRESHID50` " +
-                "ORDER BY `  FRESHID50` " +
-                "RETURN `  FRESHID50` AS `a.name`"
+                "WITH a WHERE a.age > 18 " +
+                "RETURN a.name " +
+                "ORDER BY a.name"
         );
     }
 
     @Test
-    public void matchOrderBySingleName() throws Exception {
+    public void dontRewriteMatchOrderBySingleName() throws Exception {
         assertThat(parse(
             "MATCH (a:artist) " +
                 "RETURN a.name " +
                 "ORDER BY a.name"
         )).normalizedTo(
             "MATCH (a:artist) " +
-                "WITH a.name AS `  FRESHID26` " +
-                "ORDER BY `  FRESHID26` " +
-                "RETURN `  FRESHID26` AS `a.name`"
+                 "RETURN a.name " +
+                 "ORDER BY a.name"
         );
     }
 
     @Test
-    public void matchOrderByMultipleNames() throws Exception {
+    public void dontRewriteMatchOrderByMultipleNames() throws Exception {
         assertThat(parse(
             "MATCH (a:artist)<-[:writtenBy]-(s:song) " +
                 "RETURN a.name, s.name " +
                 "ORDER BY a.name, s.name"
         )).normalizedTo(
             "MATCH (a:artist)<-[:writtenBy]-(s:song) " +
-                "WITH a.name AS `  FRESHID49`, s.name AS `  FRESHID57` " +
-                "ORDER BY `  FRESHID49`, `  FRESHID57` " +
-                "RETURN `  FRESHID49` AS `a.name`, `  FRESHID57` AS `s.name`"
+                "RETURN a.name, s.name " +
+                "ORDER BY a.name, s.name"
         );
     }
 
     @Test
-    public void matchOrderBySkipLimit() throws Exception {
+    public void dontRewriteMatchOrderBySkipLimit() throws Exception {
         assertThat(parse(
             "MATCH (a:artist) " +
                 "RETURN a.name " +
@@ -157,9 +153,9 @@ public class AstRewriterTest {
                 "SKIP 1 LIMIT 2"
         )).normalizedTo(
             "MATCH (a:artist) " +
-                "WITH a.name AS `  FRESHID26` " +
-                "ORDER BY `  FRESHID26` SKIP 1 LIMIT 2 " +
-                "RETURN `  FRESHID26` AS `a.name`"
+                "RETURN a.name " +
+                "ORDER BY a.name " +
+                "SKIP 1 LIMIT 2"
         );
     }
 


### PR DESCRIPTION
- Upgrade to frontend `9.0.2018091`
- Since 9.0.8 front-end removes `normalizeReturnClauses` which created intermediate projection for ORDER, LIMIT e.t.c
- Intermediate projection is now created in CfoG translation
- Finalization moved to separate projection
- Rewriter that removes multiple projections if not necessary

Signed-off-by: Dwitry dwitry@users.noreply.github.com