### PR TITLE
Simplify null guards

### DIFF
--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/FunctionTest.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/FunctionTest.java
@@ -18,6 +18,7 @@ package org.opencypher.gremlin.queries;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -298,6 +299,15 @@ public class FunctionTest {
         assertThat(results)
             .extracting("n.name")
             .containsExactly("marko", "josh");
+    }
 
+    @Test
+    public void propertiesOnNode() {
+        List<Map<String, Object>> results = submitAndGet(
+            "MATCH (n {name:'marko'}) RETURN properties(n) as r");
+
+        assertThat(results)
+            .extracting("r")
+            .containsExactly(ImmutableMap.of("age", 29L, "name", "marko"));
     }
 }

--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/ReturnTest.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/ReturnTest.java
@@ -503,4 +503,15 @@ public class ReturnTest {
                 .containsExactly(result);
         }
     }
+
+    @Test
+    public void optionalProjection() throws Exception {
+        String cypher = "OPTIONAL MATCH (n:notExisting) WITH (n) as m RETURN m";
+
+        List<Map<String, Object>> cypherResults = submitAndGet(cypher);
+
+        assertThat(cypherResults)
+            .extracting("m")
+            .containsExactly((Object) null);
+    }
 }

--- a/tinkerpop/cypher-gremlin-extensions/src/main/java/org/opencypher/gremlin/traversal/CustomFunctions.java
+++ b/tinkerpop/cypher-gremlin-extensions/src/main/java/org/opencypher/gremlin/traversal/CustomFunctions.java
@@ -142,6 +142,11 @@ public final class CustomFunctions {
     public static Function<Traverser, Object> cypherProperties() {
         return traverser -> {
             Object argument = traverser.get();
+
+            if (argument == Tokens.NULL) {
+                return Tokens.NULL;
+            }
+
             if (argument instanceof Map) {
                 return argument;
             }

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/ir/TranslationWriter.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/ir/TranslationWriter.scala
@@ -96,18 +96,18 @@ sealed class TranslationWriter[T, P] private (translator: Translator[T, P], para
             .getOrElse(g.by(writeLocalSteps(traversal)))
         case Cap(sideEffectKey) =>
           g.cap(sideEffectKey)
-        case ChooseC(choiceTraversal) =>
+        case ChooseT(choiceTraversal, None, None) =>
           g.choose(writeLocalSteps(choiceTraversal))
-        case ChooseT(traversalPredicate, trueChoice, falseChoice) =>
-          if (trueChoice.nonEmpty && falseChoice.nonEmpty) {
-            g.choose(writeLocalSteps(traversalPredicate), writeLocalSteps(trueChoice), writeLocalSteps(falseChoice))
-          }
-        case ChooseP(predicate, trueChoice, falseChoice) =>
-          if (trueChoice.nonEmpty && falseChoice.nonEmpty) {
-            g.choose(writePredicate(predicate), writeLocalSteps(trueChoice), writeLocalSteps(falseChoice))
-          } else if (trueChoice.nonEmpty) {
-            g.choose(writePredicate(predicate), writeLocalSteps(trueChoice))
-          }
+        case c @ ChooseT(_, None, Some(_)) =>
+          throw new UnsupportedOperationException(s"Unsupported $c")
+        case c @ ChooseT(_, Some(_), None) =>
+          throw new UnsupportedOperationException(s"Unsupported $c")
+        case ChooseT(traversalPredicate, Some(trueChoice), Some(falseChoice)) =>
+          g.choose(writeLocalSteps(traversalPredicate), writeLocalSteps(trueChoice), writeLocalSteps(falseChoice))
+        case ChooseP(predicate, trueChoice, None) =>
+          g.choose(writePredicate(predicate), writeLocalSteps(trueChoice))
+        case ChooseP(predicate, trueChoice, Some(falseChoice)) =>
+          g.choose(writePredicate(predicate), writeLocalSteps(trueChoice), writeLocalSteps(falseChoice))
         case Coalesce(coalesceTraversals @ _*) =>
           g.coalesce(coalesceTraversals.map(writeLocalSteps): _*)
         case Constant(e) =>

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/ir/builder/IRGremlinSteps.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/ir/builder/IRGremlinSteps.scala
@@ -103,7 +103,7 @@ class IRGremlinSteps extends GremlinSteps[Seq[GremlinStep], GremlinPredicate] {
 
   override def choose(choiceTraversal: GremlinSteps[Seq[GremlinStep], GremlinPredicate])
     : GremlinSteps[Seq[GremlinStep], GremlinPredicate] = {
-    buf += ChooseC(choiceTraversal.current())
+    buf += ChooseT(choiceTraversal.current())
     this
   }
 
@@ -112,7 +112,7 @@ class IRGremlinSteps extends GremlinSteps[Seq[GremlinStep], GremlinPredicate] {
       trueChoice: GremlinSteps[Seq[GremlinStep], GremlinPredicate],
       falseChoice: GremlinSteps[Seq[GremlinStep], GremlinPredicate])
     : GremlinSteps[Seq[GremlinStep], GremlinPredicate] = {
-    buf += ChooseT(traversalPredicate.current(), trueChoice.current(), falseChoice.current())
+    buf += ChooseT(traversalPredicate.current(), Some(trueChoice.current()), Some(falseChoice.current()))
     this
   }
 
@@ -121,13 +121,13 @@ class IRGremlinSteps extends GremlinSteps[Seq[GremlinStep], GremlinPredicate] {
       trueChoice: GremlinSteps[Seq[GremlinStep], GremlinPredicate],
       falseChoice: GremlinSteps[Seq[GremlinStep], GremlinPredicate])
     : GremlinSteps[Seq[GremlinStep], GremlinPredicate] = {
-    buf += ChooseP(predicate, trueChoice.current(), falseChoice.current())
+    buf += ChooseP(predicate, trueChoice.current(), Some(falseChoice.current()))
     this
   }
 
   override def choose(predicate: GremlinPredicate, trueChoice: GremlinSteps[Seq[GremlinStep], GremlinPredicate])
     : GremlinSteps[Seq[GremlinStep], GremlinPredicate] = {
-    buf += ChooseP(predicate, trueChoice.current(), Nil)
+    buf += ChooseP(predicate, trueChoice.current())
     this
   }
 

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/CustomFunctionFallback.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/CustomFunctionFallback.scala
@@ -36,7 +36,7 @@ object CustomFunctionFallback extends GremlinRewriter {
         Path :: From(text) :: rest
 
       case SelectC(values) :: MapF(function) :: rest if function.getName == cypherPlus().getName =>
-        SelectC(values) :: Local(Unfold :: ChooseP(Neq(NULL), Sum :: Nil, Constant(NULL) :: Nil) :: Nil) :: rest
+        SelectC(values) :: Local(Unfold :: ChooseP(Neq(NULL), Sum :: Nil, None) :: Nil) :: rest
 
       case MapF(function) :: rest if function.getName == cypherSize().getName =>
         CountS(local) :: rest

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/RemoveUselessNullChecks.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/RemoveUselessNullChecks.scala
@@ -37,10 +37,10 @@ object RemoveUselessNullChecks extends GremlinRewriter {
 
   private def splitSegment(steps: Seq[GremlinStep]): (Seq[GremlinStep], Seq[GremlinStep]) = {
     val (segment, rest) = steps.span {
-      case By(SelectK(_) :: ChooseP(Neq(NULL), _, Constant(NULL) :: Nil) :: Nil, None) => false
-      case By(ChooseP(Neq(NULL), _, Constant(NULL) :: Nil) :: Nil, None)               => false
-      case ChooseP(Neq(NULL), _, Constant(NULL) :: Nil)                                => false
-      case _                                                                           => true
+      case By(SelectK(_) :: ChooseP(Neq(NULL), _, None) :: Nil, None) => false
+      case By(ChooseP(Neq(NULL), _, None) :: Nil, None)               => false
+      case ChooseP(Neq(NULL), _, None)                                => false
+      case _                                                          => true
     }
     rest match {
       case head :: tail => (segment :+ head, tail)
@@ -62,11 +62,11 @@ object RemoveUselessNullChecks extends GremlinRewriter {
     }
 
     val last = steps.last match {
-      case By(SelectK(key) :: ChooseP(Neq(NULL), t, Constant(NULL) :: Nil) :: Nil, None) =>
-        By(SelectK(key) +: t, None) :: Nil
-      case By(ChooseP(Neq(NULL), t, Constant(NULL) :: Nil) :: Nil, None) =>
-        By(t, None) :: Nil
-      case ChooseP(Neq(NULL), traversal, Constant(NULL) :: Nil) =>
+      case By(SelectK(key) :: ChooseP(Neq(NULL), traversal, None) :: Nil, None) =>
+        By(SelectK(key) +: traversal, None) :: Nil
+      case By(ChooseP(Neq(NULL), traversal, None) :: Nil, None) =>
+        By(traversal, None) :: Nil
+      case ChooseP(Neq(NULL), traversal, None) =>
         traversal
       case step =>
         step :: Nil

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/SimplifyDelete.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/SimplifyDelete.scala
@@ -26,7 +26,7 @@ object SimplifyDelete extends GremlinRewriter {
   def apply(steps: Seq[GremlinStep]): Seq[GremlinStep] = {
     val withChoose = foldTraversals(false)((acc, localSteps) => {
       acc || extract({
-        case ChooseP(IsNode(), Aggregate(DELETE) :: Nil, Aggregate(DETACH_DELETE) :: Nil) :: _ => true
+        case ChooseP(IsNode(), Aggregate(DELETE) :: Nil, Some(Aggregate(DETACH_DELETE) :: Nil)) :: _ => true
       })(localSteps).contains(true)
     })(steps)
 

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/SimplifyPropertySetters.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/SimplifyPropertySetters.scala
@@ -33,7 +33,7 @@ object SimplifyPropertySetters extends GremlinRewriter {
         PropertyV(key, value) :: rest
       case PropertyTC(cardinality, key, Constant(value) :: Nil) :: rest =>
         PropertyVC(cardinality, key, value) :: rest
-      case ChooseT(_, PropertyV(key, value) :: Nil, drop) :: rest =>
+      case ChooseT(_, Some(PropertyV(key, value) :: Nil), Some(drop)) :: rest =>
         val empty = value match {
           case NULL                     => true
           case coll: util.Collection[_] => coll.isEmpty
@@ -44,7 +44,7 @@ object SimplifyPropertySetters extends GremlinRewriter {
         } else {
           PropertyV(key, value) :: rest
         }
-      case step @ ChooseT(_, prop @ PropertyT(_, Project(_*) :: valueTail) :: Nil, _) :: rest
+      case step @ ChooseT(_, Some(prop @ PropertyT(_, Project(_*) :: valueTail) :: Nil), _) :: rest
           if valueTail.init.forall(_.isInstanceOf[By]) =>
         valueTail.last match {
           case _: By | _: SelectC => prop ++ rest

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/walker/NodeUtils.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/walker/NodeUtils.scala
@@ -125,7 +125,7 @@ object NodeUtils {
   def notNull[T, P](traversal: GremlinSteps[T, P], context: WalkerContext[T, P]): GremlinSteps[T, P] = {
     val g = context.dsl.steps()
     val p = context.dsl.predicates()
-    g.start().choose(p.neq(NULL), traversal, g.start().constant(NULL))
+    g.start().choose(p.neq(NULL), traversal)
   }
 
   def emptyToNull[T, P](traversal: GremlinSteps[T, P], context: WalkerContext[T, P]): GremlinSteps[T, P] = {

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/walker/ProjectionWalker.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/walker/ProjectionWalker.scala
@@ -269,10 +269,6 @@ private class ProjectionWalker[T, P](context: WalkerContext[T, P], g: GremlinSte
     dependencyNames.distinct
   }
 
-  private def notNull(traversal: GremlinSteps[T, P]): GremlinSteps[T, P] = {
-    NodeUtils.notNull(traversal, context)
-  }
-
   private def subTraversal(alias: String, expression: Expression): (ReturnFunctionType, GremlinSteps[T, P]) = {
     if (expression.containsAggregate) {
       aggregation(alias, expression)
@@ -313,6 +309,10 @@ private class ProjectionWalker[T, P](context: WalkerContext[T, P], g: GremlinSte
             .is(p.neq(START))
             .valueMap(true)
             .fold())
+
+    def notNull(traversal: GremlinSteps[T, P]): GremlinSteps[T, P] = {
+      NodeUtils.notNull(traversal, context)
+    }
 
     qualifiedType(expression) match {
       case (_: NodeType, _) =>

--- a/translation/src/test/scala/org/opencypher/gremlin/translation/ir/rewrite/CustomFunctionsFallbackTest.scala
+++ b/translation/src/test/scala/org/opencypher/gremlin/translation/ir/rewrite/CustomFunctionsFallbackTest.scala
@@ -59,7 +59,7 @@ class CustomFunctionsFallbackTest {
       .removes(__.select(Column.values).map(CustomFunction.cypherPlus()))
       .adds(
         __.select(Column.values)
-          .local(__.unfold().choose(P.neq(Tokens.NULL), __.sum(), __.start().constant(Tokens.NULL))))
+          .local(__.unfold().choose(P.neq(Tokens.NULL), __.sum())))
   }
 
   @Test

--- a/translation/src/test/scala/org/opencypher/gremlin/translation/ir/rewrite/RemoveUselessNullChecksTest.scala
+++ b/translation/src/test/scala/org/opencypher/gremlin/translation/ir/rewrite/RemoveUselessNullChecksTest.scala
@@ -41,7 +41,7 @@ class RemoveUselessNullChecksTest {
       """.stripMargin))
       .withFlavor(flavor)
       .rewritingWith(RemoveUselessNullChecks)
-      .removes(__.by(__.choose(P.neq(NULL), __.valueMap(true), __.constant(NULL))))
+      .removes(__.by(__.choose(P.neq(NULL), __.valueMap(true))))
       .adds(__.by(__.valueMap(true)))
   }
 
@@ -53,8 +53,8 @@ class RemoveUselessNullChecksTest {
       """.stripMargin))
       .withFlavor(flavor)
       .rewritingWith(RemoveUselessNullChecks)
-      .removes(__.by(__.select("n").choose(P.neq(NULL), __.valueMap(true), __.constant(NULL))))
-      .removes(__.by(__.select("m").choose(P.neq(NULL), __.valueMap(true), __.constant(NULL))))
+      .removes(__.by(__.select("n").choose(P.neq(NULL), __.valueMap(true))))
+      .removes(__.by(__.select("m").choose(P.neq(NULL), __.valueMap(true))))
       .adds(__.by(__.select("n").valueMap(true)))
       .adds(__.by(__.select("m").valueMap(true)))
   }

--- a/translation/src/test/scala/org/opencypher/gremlin/translation/ir/rewrite/RemoveUselessNullChecksTest.scala
+++ b/translation/src/test/scala/org/opencypher/gremlin/translation/ir/rewrite/RemoveUselessNullChecksTest.scala
@@ -58,4 +58,103 @@ class RemoveUselessNullChecksTest {
       .adds(__.by(__.select("n").valueMap(true)))
       .adds(__.by(__.select("m").valueMap(true)))
   }
+
+  @Test
+  def singleOptionalProjection(): Unit = {
+    assertThat(parse("""
+        |OPTIONAL MATCH (n)
+        |RETURN n
+      """.stripMargin))
+      .withFlavor(flavor)
+      .rewritingWith(RemoveUselessNullChecks)
+      .keeps(__.choose(P.neq(NULL), __.valueMap(true)))
+  }
+
+  @Test
+  def functionInvocation(): Unit = {
+    assertThat(parse("""
+      MATCH (n:notExising) WITH n AS n RETURN head(collect(n)) AS head
+      """.stripMargin))
+      .withFlavor(flavor)
+      .rewritingWith(RemoveUselessNullChecks)
+      .keeps(__.choose(P.neq(NULL), __.valueMap(true)))
+  }
+
+  @Test
+  def multipleOptionalProjections(): Unit = {
+    assertThat(parse("""
+        |OPTIONAL MATCH (n)-->(m)
+        |RETURN n, m
+      """.stripMargin))
+      .withFlavor(flavor)
+      .keeps(__.select("n").choose(P.neq(NULL), __.valueMap(true)))
+      .keeps(__.select("m").choose(P.neq(NULL), __.valueMap(true)))
+  }
+
+  @Test
+  def optionalWithProjection(): Unit = {
+    assertThat(parse("""
+        |OPTIONAL MATCH (n:notExisting) WITH (n) as m RETURN m
+      """.stripMargin))
+      .withFlavor(flavor)
+      .contains(__.choose(P.neq(NULL), __.valueMap(true)))
+  }
+
+  @Test
+  def create(): Unit = {
+    assertThat(parse("""
+        |CREATE (n)-[r:knows]->(m) RETURN n, r, m
+      """.stripMargin))
+      .withFlavor(flavor)
+      .rewritingWith(RemoveUselessNullChecks)
+      .removes(__.by(__.select("n").choose(P.neq(NULL), __.valueMap(true))))
+      .removes(
+        __.by(
+          __.select("r")
+            .choose(
+              P.neq("  cypher.null"),
+              __.project("  cypher.element", "  cypher.inv", "  cypher.outv")
+                .by(__.valueMap(true))
+                .by(__.inV().id())
+                .by(__.outV().id()))))
+      .removes(__.by(__.select("m").choose(P.neq(NULL), __.valueMap(true))))
+      .adds(__.by(__.select("n").valueMap(true)))
+      .adds(
+        __.by(
+          __.select("r")
+            .project("  cypher.element", "  cypher.inv", "  cypher.outv")
+            .by(__.valueMap(true))
+            .by(__.inV().id())
+            .by(__.outV().id())))
+      .adds(__.by(__.select("m").valueMap(true)))
+  }
+
+  @Test
+  def merge(): Unit = {
+    assertThat(parse("""
+        |MERGE (n)-[r:knows]->(m) RETURN n, r, m
+      """.stripMargin))
+      .withFlavor(flavor)
+      .rewritingWith(RemoveUselessNullChecks)
+      .removes(__.by(__.select("n").choose(P.neq(NULL), __.valueMap(true))))
+      .removes(
+        __.by(
+          __.select("r")
+            .choose(
+              P.neq("  cypher.null"),
+              __.project("  cypher.element", "  cypher.inv", "  cypher.outv")
+                .by(__.valueMap(true))
+                .by(__.inV().id())
+                .by(__.outV().id()))))
+      .removes(__.by(__.select("m").choose(P.neq(NULL), __.valueMap(true))))
+      .adds(__.by(__.select("n").valueMap(true)))
+      .adds(
+        __.by(
+          __.select("r")
+            .project("  cypher.element", "  cypher.inv", "  cypher.outv")
+            .by(__.valueMap(true))
+            .by(__.inV().id())
+            .by(__.outV().id())))
+      .adds(__.by(__.select("m").valueMap(true)))
+  }
 }


### PR DESCRIPTION
- Omit unnecessary `_.constant(NULL)` in null guards:
  - `choose(p.neq(NULL), traversal, constant(NULL))` → `choose(p.neq(NULL), traversal)`
- Use `NodeUtils#notNull` in projection walker
- Skip null checks in gremlin steps that handle `  cypher.null`: `limit`, `tail`, `range`, `identity`
- More tests for nulls