### PR TITLE
Fixed related bugs with `fold` and rewriting

### DIFF
--- a/translation/src/test/scala/org/opencypher/gremlin/translation/ir/rewrite/RemoveUselessStepsTest.scala
+++ b/translation/src/test/scala/org/opencypher/gremlin/translation/ir/rewrite/RemoveUselessStepsTest.scala
@@ -25,17 +25,14 @@ class RemoveUselessStepsTest {
 
   val flavor = new TranslatorFlavor(
     rewriters = Seq(
-      InlineFlatMapTraversal
+      InlineFlatMapTraversal,
+      SimplifySingleProjections
     ),
     postConditions = Nil
   )
 
   @Test def foldUnfold(): Unit = {
-    assertThat(parse("""
-        |MATCH (n)
-        |UNWIND labels(n) as l
-        |RETURN l
-      """.stripMargin))
+    assertThat(parse("MATCH (n) RETURN count(*)"))
       .withFlavor(flavor)
       .rewritingWith(RemoveUselessSteps)
       .removes(__.fold().unfold())


### PR DESCRIPTION
- `fold()` loses traversal history (e.g. `g.V().as('a').fold().select('a')` returns noting)
- In cases where `fold()` is used for collection creation, replaced with `map(fold())` (e.g. `g.V().as('a').map(fold()).select('a')`)
- Fix `SimplifySingleProjections` rewriter removing valid re-`select`

TCK +2

Signed-off-by: Dwitry dwitry@users.noreply.github.com