### PR TITLE
Consider nullability and type in predicates:

### DIFF
--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/NullTest.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/NullTest.java
@@ -122,4 +122,21 @@ public class NullTest {
             .extracting("cnt")
             .containsExactly(0L);
     }
+
+    /**
+     * Custom predicate deserialization is not implemented
+     */
+    @Test
+    @Category(SkipWithBytecode.class)
+    public void nullOnIncompatibleTypes() {
+        submitAndGet(" CREATE ({val: 1})");
+
+        List<Map<String, Object>> results = submitAndGet(
+            "MATCH (n) RETURN 'a' STARTS WITH n.val as r"
+        );
+
+        assertThat(results)
+            .extracting("r")
+            .containsExactly((Object) null);
+    }
 }

--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/NullTest.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/NullTest.java
@@ -22,6 +22,8 @@ import java.util.Map;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.opencypher.gremlin.groups.SkipWithBytecode;
 import org.opencypher.gremlin.rules.GremlinServerExternalResource;
 
 public class NullTest {
@@ -62,5 +64,62 @@ public class NullTest {
         assertThat(results)
             .extracting("a")
             .containsExactly((Object) null);
+    }
+
+    /**
+     * Custom predicate deserialization is not implemented
+     */
+    @Test
+    @Category(SkipWithBytecode.class)
+    public void predicateOnNull() {
+        submitAndGet("CREATE (a)");
+
+        List<Map<String, Object>> results = submitAndGet(
+            "MATCH (a)\n" +
+                "WHERE a.name CONTAINS 'b'\n" +
+                "RETURN count(a) as cnt"
+        );
+
+        assertThat(results)
+            .extracting("cnt")
+            .containsExactly(0L);
+    }
+
+    /**
+     * Custom predicate deserialization is not implemented
+     */
+    @Test
+    @Category(SkipWithBytecode.class)
+    public void negationOfPredicateOnNullLhs() {
+        submitAndGet("CREATE (a)");
+
+        List<Map<String, Object>> results = submitAndGet(
+            "MATCH (a)\n" +
+                "WHERE NOT a.name CONTAINS 'b'\n" +
+                "RETURN count(a) as cnt"
+        );
+
+        assertThat(results)
+            .extracting("cnt")
+            .containsExactly(0L);
+    }
+
+    /**
+     * Custom predicate deserialization is not implemented
+     */
+    @Test
+    @Category(SkipWithBytecode.class)
+    public void negationOfPredicateOnNullRhs() {
+        submitAndGet("CREATE ({name: 'a'})");
+
+        List<Map<String, Object>> results = submitAndGet(
+            "MATCH (a)\n" +
+                "WHERE NOT a.name CONTAINS null\n" +
+                "RETURN count(a) as cnt"
+        );
+
+        assertThat(results)
+            .extracting("cnt")
+            .containsExactly(0L);
     }
 }

--- a/tinkerpop/cypher-gremlin-extensions/src/main/java/org/opencypher/gremlin/traversal/CustomPredicate.java
+++ b/tinkerpop/cypher-gremlin-extensions/src/main/java/org/opencypher/gremlin/traversal/CustomPredicate.java
@@ -47,6 +47,13 @@ public enum CustomPredicate implements BiPredicate<Object, Object> {
         public boolean test(Object a, Object b) {
             return a instanceof Vertex;
         }
+    },
+
+    cypherIsString {
+        @Override
+        public boolean test(Object a, Object b) {
+            return a instanceof String;
+        }
     };
 
     public static P<Object> cypherStartsWith(final Object prefix) {
@@ -63,5 +70,9 @@ public enum CustomPredicate implements BiPredicate<Object, Object> {
 
     public static P<Object> cypherIsNode() {
         return new P<>(CustomPredicate.cypherIsNode, null);
+    }
+
+    public static P<Object> cypherIsString() {
+        return new P<>(CustomPredicate.cypherIsString, null);
     }
 }

--- a/tinkerpop/cypher-gremlin-extensions/src/main/java/org/opencypher/gremlin/traversal/CustomPredicate.java
+++ b/tinkerpop/cypher-gremlin-extensions/src/main/java/org/opencypher/gremlin/traversal/CustomPredicate.java
@@ -24,21 +24,21 @@ public enum CustomPredicate implements BiPredicate<Object, Object> {
     cypherStartsWith {
         @Override
         public boolean test(Object a, Object b) {
-            return a != null && b != null && a.toString().startsWith(b.toString());
+            return a.toString().startsWith(b.toString());
         }
     },
 
     cypherEndsWith {
         @Override
         public boolean test(Object a, Object b) {
-            return a != null && b != null && a.toString().endsWith(b.toString());
+            return a.toString().endsWith(b.toString());
         }
     },
 
     cypherContains {
         @Override
         public boolean test(Object a, Object b) {
-            return a != null && b != null && a.toString().contains(b.toString());
+            return a.toString().contains(b.toString());
         }
     },
 

--- a/translation/src/main/java/org/opencypher/gremlin/translation/GremlinPredicates.java
+++ b/translation/src/main/java/org/opencypher/gremlin/translation/GremlinPredicates.java
@@ -53,4 +53,6 @@ public interface GremlinPredicates<P> {
     P contains(Object value);
 
     P isNode();
+
+    P isString();
 }

--- a/translation/src/main/java/org/opencypher/gremlin/translation/bytecode/BytecodeGremlinPredicates.java
+++ b/translation/src/main/java/org/opencypher/gremlin/translation/bytecode/BytecodeGremlinPredicates.java
@@ -88,6 +88,11 @@ public class BytecodeGremlinPredicates implements GremlinPredicates<P> {
         return CustomPredicate.cypherIsNode();
     }
 
+    @Override
+    public P isString() {
+        return CustomPredicate.cypherIsString();
+    }
+
     private static Object[] inlineParameters(Object... values) {
         return Stream.of(values)
             .map(BytecodeGremlinPredicates::inlineParameter)

--- a/translation/src/main/java/org/opencypher/gremlin/translation/groovy/GroovyGremlinPredicates.java
+++ b/translation/src/main/java/org/opencypher/gremlin/translation/groovy/GroovyGremlinPredicates.java
@@ -87,4 +87,9 @@ public class GroovyGremlinPredicates implements GremlinPredicates<GroovyPredicat
     public GroovyPredicate isNode() {
         return new GroovyPredicate("cypherIsNode");
     }
+
+    @Override
+    public GroovyPredicate isString() {
+        return new GroovyPredicate("cypherIsString");
+    }
 }

--- a/translation/src/main/java/org/opencypher/gremlin/translation/traversal/TraversalGremlinPredicates.java
+++ b/translation/src/main/java/org/opencypher/gremlin/translation/traversal/TraversalGremlinPredicates.java
@@ -85,4 +85,9 @@ public class TraversalGremlinPredicates implements GremlinPredicates<P> {
     public P isNode() {
         return CustomPredicate.cypherIsNode();
     }
+
+    @Override
+    public P isString() {
+        return CustomPredicate.cypherIsString();
+    }
 }

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/ir/TranslationWriter.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/ir/TranslationWriter.scala
@@ -96,17 +96,13 @@ sealed class TranslationWriter[T, P] private (translator: Translator[T, P], para
             .getOrElse(g.by(writeLocalSteps(traversal)))
         case Cap(sideEffectKey) =>
           g.cap(sideEffectKey)
-        case ChooseT(choiceTraversal, None, None) =>
+        case ChooseT1(choiceTraversal) =>
           g.choose(writeLocalSteps(choiceTraversal))
-        case c @ ChooseT(_, None, Some(_)) =>
-          throw new UnsupportedOperationException(s"Unsupported $c")
-        case c @ ChooseT(_, Some(_), None) =>
-          throw new UnsupportedOperationException(s"Unsupported $c")
-        case ChooseT(traversalPredicate, Some(trueChoice), Some(falseChoice)) =>
+        case ChooseT3(traversalPredicate, trueChoice, falseChoice) =>
           g.choose(writeLocalSteps(traversalPredicate), writeLocalSteps(trueChoice), writeLocalSteps(falseChoice))
-        case ChooseP(predicate, trueChoice, None) =>
+        case ChooseP2(predicate, trueChoice) =>
           g.choose(writePredicate(predicate), writeLocalSteps(trueChoice))
-        case ChooseP(predicate, trueChoice, Some(falseChoice)) =>
+        case ChooseP3(predicate, trueChoice, falseChoice) =>
           g.choose(writePredicate(predicate), writeLocalSteps(trueChoice), writeLocalSteps(falseChoice))
         case Coalesce(coalesceTraversals @ _*) =>
           g.coalesce(coalesceTraversals.map(writeLocalSteps): _*)
@@ -270,6 +266,7 @@ sealed class TranslationWriter[T, P] private (translator: Translator[T, P], para
       case EndsWith(value)        => p.endsWith(writeValue(value))
       case Contains(value)        => p.contains(writeValue(value))
       case IsNode()               => p.isNode
+      case IsString()             => p.isString
     }
   }
 

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/ir/builder/IRGremlinPredicates.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/ir/builder/IRGremlinPredicates.scala
@@ -44,4 +44,6 @@ class IRGremlinPredicates extends GremlinPredicates[GremlinPredicate] {
   override def contains(value: scala.Any): GremlinPredicate = Contains(value)
 
   override def isNode: GremlinPredicate = IsNode()
+
+  override def isString: GremlinPredicate = IsString()
 }

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/ir/builder/IRGremlinSteps.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/ir/builder/IRGremlinSteps.scala
@@ -103,7 +103,7 @@ class IRGremlinSteps extends GremlinSteps[Seq[GremlinStep], GremlinPredicate] {
 
   override def choose(choiceTraversal: GremlinSteps[Seq[GremlinStep], GremlinPredicate])
     : GremlinSteps[Seq[GremlinStep], GremlinPredicate] = {
-    buf += ChooseT(choiceTraversal.current())
+    buf += ChooseT1(choiceTraversal.current())
     this
   }
 
@@ -112,7 +112,7 @@ class IRGremlinSteps extends GremlinSteps[Seq[GremlinStep], GremlinPredicate] {
       trueChoice: GremlinSteps[Seq[GremlinStep], GremlinPredicate],
       falseChoice: GremlinSteps[Seq[GremlinStep], GremlinPredicate])
     : GremlinSteps[Seq[GremlinStep], GremlinPredicate] = {
-    buf += ChooseT(traversalPredicate.current(), Some(trueChoice.current()), Some(falseChoice.current()))
+    buf += ChooseT3(traversalPredicate.current(), trueChoice.current(), falseChoice.current())
     this
   }
 
@@ -121,13 +121,13 @@ class IRGremlinSteps extends GremlinSteps[Seq[GremlinStep], GremlinPredicate] {
       trueChoice: GremlinSteps[Seq[GremlinStep], GremlinPredicate],
       falseChoice: GremlinSteps[Seq[GremlinStep], GremlinPredicate])
     : GremlinSteps[Seq[GremlinStep], GremlinPredicate] = {
-    buf += ChooseP(predicate, trueChoice.current(), Some(falseChoice.current()))
+    buf += ChooseP3(predicate, trueChoice.current(), falseChoice.current())
     this
   }
 
   override def choose(predicate: GremlinPredicate, trueChoice: GremlinSteps[Seq[GremlinStep], GremlinPredicate])
     : GremlinSteps[Seq[GremlinStep], GremlinPredicate] = {
-    buf += ChooseP(predicate, trueChoice.current())
+    buf += ChooseP2(predicate, trueChoice.current())
     this
   }
 

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/ir/model/GremlinPredicate.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/ir/model/GremlinPredicate.scala
@@ -30,3 +30,4 @@ case class StartsWith(value: Any) extends GremlinPredicate
 case class EndsWith(value: Any) extends GremlinPredicate
 case class Contains(value: Any) extends GremlinPredicate
 case class IsNode() extends GremlinPredicate
+case class IsString() extends GremlinPredicate

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/ir/model/GremlinStep.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/ir/model/GremlinStep.scala
@@ -69,7 +69,7 @@ case object Barrier extends GremlinStep
 
 case class BothE(edgeLabels: String*) extends GremlinStep
 
-case class By(traversal: Seq[GremlinStep], order: Option[TraversalOrder] = None) extends GremlinStep {
+case class By(traversal: Seq[GremlinStep], order: Option[TraversalOrder]) extends GremlinStep {
   override def mapTraversals(f: Seq[GremlinStep] => Seq[GremlinStep]): GremlinStep = {
     By(f(traversal), order)
   }
@@ -81,36 +81,45 @@ case class By(traversal: Seq[GremlinStep], order: Option[TraversalOrder] = None)
 
 case class Cap(sideEffectKey: String) extends GremlinStep
 
-case class ChooseT(
-    traversalPredicate: Seq[GremlinStep],
-    trueChoice: Option[Seq[GremlinStep]] = None,
-    falseChoice: Option[Seq[GremlinStep]] = None)
-    extends GremlinStep {
-
+case class ChooseT1(choiceTraversal: Seq[GremlinStep]) extends GremlinStep {
   override def mapTraversals(f: Seq[GremlinStep] => Seq[GremlinStep]): GremlinStep = {
-    ChooseT(f(traversalPredicate), trueChoice.map(f(_)), falseChoice.map(f(_)))
+    ChooseT1(f(choiceTraversal))
   }
 
   override def foldTraversals[R](z: R)(op: (R, Seq[GremlinStep]) => R): R = {
-    val predicateFold = op(z, traversalPredicate)
-    val trueChoiceFold = trueChoice.map(op(predicateFold, _)).getOrElse(predicateFold)
-    falseChoice.map(op(trueChoiceFold, _)).getOrElse(trueChoiceFold)
+    op(z, choiceTraversal)
   }
 }
 
-case class ChooseP(
-    predicate: GremlinPredicate,
-    trueChoice: Seq[GremlinStep],
-    falseChoice: Option[Seq[GremlinStep]] = None)
+case class ChooseT3(traversalPredicate: Seq[GremlinStep], trueChoice: Seq[GremlinStep], falseChoice: Seq[GremlinStep])
     extends GremlinStep {
-
   override def mapTraversals(f: Seq[GremlinStep] => Seq[GremlinStep]): GremlinStep = {
-    ChooseP(predicate, f(trueChoice), falseChoice.map(f(_)))
+    ChooseT3(f(traversalPredicate), f(trueChoice), f(falseChoice))
   }
 
   override def foldTraversals[R](z: R)(op: (R, Seq[GremlinStep]) => R): R = {
-    val trueChoiceFold = op(z, trueChoice)
-    falseChoice.map(op(trueChoiceFold, _)).getOrElse(trueChoiceFold)
+    op(op(op(z, traversalPredicate), trueChoice), falseChoice)
+  }
+}
+
+case class ChooseP2(predicate: GremlinPredicate, trueChoice: Seq[GremlinStep]) extends GremlinStep {
+  override def mapTraversals(f: Seq[GremlinStep] => Seq[GremlinStep]): GremlinStep = {
+    ChooseP2(predicate, f(trueChoice))
+  }
+
+  override def foldTraversals[R](z: R)(op: (R, Seq[GremlinStep]) => R): R = {
+    op(z, trueChoice)
+  }
+}
+
+case class ChooseP3(predicate: GremlinPredicate, trueChoice: Seq[GremlinStep], falseChoice: Seq[GremlinStep])
+    extends GremlinStep {
+  override def mapTraversals(f: Seq[GremlinStep] => Seq[GremlinStep]): GremlinStep = {
+    ChooseP3(predicate, f(trueChoice), f(falseChoice))
+  }
+
+  override def foldTraversals[R](z: R)(op: (R, Seq[GremlinStep]) => R): R = {
+    op(op(z, trueChoice), falseChoice)
   }
 }
 

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/CustomFunctionFallback.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/CustomFunctionFallback.scala
@@ -36,7 +36,7 @@ object CustomFunctionFallback extends GremlinRewriter {
         Path :: From(text) :: rest
 
       case SelectC(values) :: MapF(function) :: rest if function.getName == cypherPlus().getName =>
-        SelectC(values) :: Local(Unfold :: ChooseP(Neq(NULL), Sum :: Nil, None) :: Nil) :: rest
+        SelectC(values) :: Local(Unfold :: ChooseP2(Neq(NULL), Sum :: Nil) :: Nil) :: rest
 
       case MapF(function) :: rest if function.getName == cypherSize().getName =>
         CountS(local) :: rest

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/RemoveIdentityReselect.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/RemoveIdentityReselect.scala
@@ -34,8 +34,8 @@ object RemoveIdentityReselect extends GremlinRewriter {
 
   private def removeReselect(steps: Seq[GremlinStep], stepLabel: String): Seq[GremlinStep] = {
     val (filters, suffix) = steps.span {
-      case _: HasP | _: HasLabel => true
-      case _                     => false
+      case _: HasP | _: HasLabel | _: Is => true
+      case _                             => false
     }
     suffix match {
       case SelectK(selectKey) :: rest if stepLabel == selectKey =>

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/RemoveUnusedAliases.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/RemoveUnusedAliases.scala
@@ -74,6 +74,7 @@ object RemoveUnusedAliases extends GremlinRewriter {
       case EndsWith(value)        => strings(value)
       case Contains(value)        => strings(value)
       case IsNode()               => Seq()
+      case IsString()             => Seq()
     }
   }
 }

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/RemoveUselessNullChecks.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/RemoveUselessNullChecks.scala
@@ -37,10 +37,10 @@ object RemoveUselessNullChecks extends GremlinRewriter {
 
   private def splitSegment(steps: Seq[GremlinStep]): (Seq[GremlinStep], Seq[GremlinStep]) = {
     val (segment, rest) = steps.span {
-      case By(SelectK(_) :: ChooseP(Neq(NULL), _, None) :: Nil, None) => false
-      case By(ChooseP(Neq(NULL), _, None) :: Nil, None)               => false
-      case ChooseP(Neq(NULL), _, None)                                => false
-      case _                                                          => true
+      case By(SelectK(_) :: ChooseP2(Neq(NULL), _) :: Nil, None) => false
+      case By(ChooseP2(Neq(NULL), _) :: Nil, None)               => false
+      case ChooseP2(Neq(NULL), _)                                => false
+      case _                                                     => true
     }
     rest match {
       case head :: tail => (segment :+ head, tail)
@@ -62,11 +62,11 @@ object RemoveUselessNullChecks extends GremlinRewriter {
     }
 
     val last = steps.last match {
-      case By(SelectK(key) :: ChooseP(Neq(NULL), traversal, None) :: Nil, None) =>
+      case By(SelectK(key) :: ChooseP2(Neq(NULL), traversal) :: Nil, None) =>
         By(SelectK(key) +: traversal, None) :: Nil
-      case By(ChooseP(Neq(NULL), traversal, None) :: Nil, None) =>
+      case By(ChooseP2(Neq(NULL), traversal) :: Nil, None) =>
         By(traversal, None) :: Nil
-      case ChooseP(Neq(NULL), traversal, None) =>
+      case ChooseP2(Neq(NULL), traversal) =>
         traversal
       case step =>
         step :: Nil

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/SimplifyDelete.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/SimplifyDelete.scala
@@ -26,7 +26,7 @@ object SimplifyDelete extends GremlinRewriter {
   def apply(steps: Seq[GremlinStep]): Seq[GremlinStep] = {
     val withChoose = foldTraversals(false)((acc, localSteps) => {
       acc || extract({
-        case ChooseP(IsNode(), Aggregate(DELETE) :: Nil, Some(Aggregate(DETACH_DELETE) :: Nil)) :: _ => true
+        case ChooseP3(IsNode(), Aggregate(DELETE) :: Nil, Aggregate(DETACH_DELETE) :: Nil) :: _ => true
       })(localSteps).contains(true)
     })(steps)
 

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/SimplifyPropertySetters.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/SimplifyPropertySetters.scala
@@ -33,7 +33,7 @@ object SimplifyPropertySetters extends GremlinRewriter {
         PropertyV(key, value) :: rest
       case PropertyTC(cardinality, key, Constant(value) :: Nil) :: rest =>
         PropertyVC(cardinality, key, value) :: rest
-      case ChooseT(_, Some(PropertyV(key, value) :: Nil), Some(drop)) :: rest =>
+      case ChooseT3(_, PropertyV(key, value) :: Nil, drop) :: rest =>
         val empty = value match {
           case NULL                     => true
           case coll: util.Collection[_] => coll.isEmpty
@@ -44,7 +44,7 @@ object SimplifyPropertySetters extends GremlinRewriter {
         } else {
           PropertyV(key, value) :: rest
         }
-      case step @ ChooseT(_, Some(prop @ PropertyT(_, Project(_*) :: valueTail) :: Nil), _) :: rest
+      case step @ ChooseT3(_, prop @ PropertyT(_, Project(_*) :: valueTail) :: Nil, _) :: rest
           if valueTail.init.forall(_.isInstanceOf[By]) =>
         valueTail.last match {
           case _: By | _: SelectC => prop ++ rest

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/ir/verify/NoCustomFunctions.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/ir/verify/NoCustomFunctions.scala
@@ -41,10 +41,10 @@ object NoCustomFunctions extends GremlinPostCondition {
     })(steps)
 
     val predicates = extract({
-      case ChooseP(predicate, _, _) :: _ => predicate
-      case HasP(_, predicate) :: _       => predicate
-      case Is(predicate) :: _            => predicate
-      case WhereP(predicate) :: _        => predicate
+      case ChooseP3(predicate, _, _) :: _ => predicate
+      case HasP(_, predicate) :: _        => predicate
+      case Is(predicate) :: _             => predicate
+      case WhereP(predicate) :: _         => predicate
     })(steps)
       .flatMap({
         case _: StartsWith => Some("cypherStarsWith")

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/walker/ExpressionWalker.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/walker/ExpressionWalker.scala
@@ -100,9 +100,9 @@ private class ExpressionWalker[T, P](context: WalkerContext[T, P], g: GremlinSte
       case LessThanOrEqual(lhs, rhs)    => comparison(lhs, rhs, p.lte)
       case GreaterThan(lhs, rhs)        => comparison(lhs, rhs, p.gt)
       case GreaterThanOrEqual(lhs, rhs) => comparison(lhs, rhs, p.gte)
-      case StartsWith(lhs, rhs)         => comparison(lhs, rhs, p.startsWith)
-      case EndsWith(lhs, rhs)           => comparison(lhs, rhs, p.endsWith)
-      case Contains(lhs, rhs)           => comparison(lhs, rhs, p.contains)
+      case StartsWith(lhs, rhs)         => comparison(lhs, rhs, p.isString, p.startsWith)
+      case EndsWith(lhs, rhs)           => comparison(lhs, rhs, p.isString, p.endsWith)
+      case Contains(lhs, rhs)           => comparison(lhs, rhs, p.isString, p.contains)
 
       case In(lhs, rhs) =>
         membership(lhs, rhs)
@@ -378,6 +378,32 @@ private class ExpressionWalker[T, P](context: WalkerContext[T, P], g: GremlinSte
     val rhsName = context.generateName()
     val traversal = anyMatch(__.where(predicate(rhsName)))
     bothNotNull(lhs, rhs, traversal, rhsName)
+  }
+
+  private def comparison(
+      lhs: Expression,
+      rhs: Expression,
+      typePredicate: P,
+      predicate: String => P): GremlinSteps[T, P] = {
+    val rhsName = context.generateName()
+    val ifTrue = anyMatch(__.where(predicate(rhsName)))
+    val p = context.dsl.predicates()
+
+    val lhsT = walkLocal(lhs)
+    val rhsT = walkLocal(rhs)
+
+    rhsT
+      .as(rhsName)
+      .flatMap(lhsT)
+      .choose(
+        __.or(
+          __.is(p.isEq(NULL)),
+          __.not(__.is(typePredicate)),
+          __.select(rhsName).is(p.isEq(NULL)),
+          __.not(__.select(rhsName).is(typePredicate))),
+        __.constant(NULL),
+        ifTrue
+      )
   }
 
   private def membership(lhs: Expression, rhs: Expression): GremlinSteps[T, P] = {

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/walker/ProjectionWalker.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/walker/ProjectionWalker.scala
@@ -59,6 +59,8 @@ private class ProjectionWalker[T, P](context: WalkerContext[T, P], g: GremlinSte
   case object Expression extends ReturnFunctionType
   case object Pivot extends ReturnFunctionType
 
+  private val p = context.dsl.predicates()
+
   def walk(
       distinct: Boolean,
       items: Seq[ReturnItem],
@@ -211,7 +213,7 @@ private class ProjectionWalker[T, P](context: WalkerContext[T, P], g: GremlinSte
     expression match {
       case _: Add | _: ContainerIndex | _: CountStar | _: Divide | _: FunctionInvocation | _: ListLiteral | _: Literal |
           _: MapExpression | _: Modulo | _: Multiply | _: Null | _: Parameter | _: PatternComprehension | _: Pow |
-          _: Property | _: Subtract | _: Variable =>
+          _: Property | _: Subtract | _: Variable | _: StartsWith | _: Contains | _: EndsWith =>
         false
       case _ =>
         true
@@ -281,7 +283,6 @@ private class ProjectionWalker[T, P](context: WalkerContext[T, P], g: GremlinSte
       subTraversal: GremlinSteps[T, P],
       variable: String,
       expression: Expression): GremlinSteps[T, P] = {
-    val p = context.dsl.predicates()
 
     lazy val finalizeNode =
       __.valueMap(true)
@@ -351,8 +352,6 @@ private class ProjectionWalker[T, P](context: WalkerContext[T, P], g: GremlinSte
     }
 
   private def aggregation(alias: String, expression: Expression): (ReturnFunctionType, GremlinSteps[T, P]) = {
-    val p = context.dsl.predicates()
-
     expression match {
       case FunctionInvocation(_, FunctionName(fnName), distinct, args) =>
         if (args.flatMap(n => n +: n.subExpressions).exists {

--- a/translation/src/test/java/org/opencypher/gremlin/traversal/CustomPredicateTest.java
+++ b/translation/src/test/java/org/opencypher/gremlin/traversal/CustomPredicateTest.java
@@ -24,27 +24,18 @@ public class CustomPredicateTest {
     public void startsWith() throws Exception {
         assertThat(CustomPredicate.cypherStartsWith("a").test("abcd")).isTrue();
         assertThat(CustomPredicate.cypherStartsWith("x").test("abcd")).isFalse();
-        assertThat(CustomPredicate.cypherStartsWith("x").test(null)).isFalse();
-        assertThat(CustomPredicate.cypherStartsWith(null).test("abcd")).isFalse();
-        assertThat(CustomPredicate.cypherStartsWith(null).test(null)).isFalse();
     }
 
     @Test
     public void endsWith() throws Exception {
         assertThat(CustomPredicate.cypherEndsWith("d").test("abcd")).isTrue();
         assertThat(CustomPredicate.cypherEndsWith("x").test("abcd")).isFalse();
-        assertThat(CustomPredicate.cypherEndsWith("x").test(null)).isFalse();
-        assertThat(CustomPredicate.cypherEndsWith(null).test("abcd")).isFalse();
-        assertThat(CustomPredicate.cypherEndsWith(null).test(null)).isFalse();
     }
 
     @Test
     public void contains() throws Exception {
         assertThat(CustomPredicate.cypherContains("bc").test("abcd")).isTrue();
         assertThat(CustomPredicate.cypherContains("x").test("abcd")).isFalse();
-        assertThat(CustomPredicate.cypherContains("x").test(null)).isFalse();
-        assertThat(CustomPredicate.cypherContains(null).test("abcd")).isFalse();
-        assertThat(CustomPredicate.cypherContains(null).test(null)).isFalse();
     }
 
 }

--- a/translation/src/test/scala/org/opencypher/gremlin/translation/ir/rewrite/GroupStepFiltersTest.scala
+++ b/translation/src/test/scala/org/opencypher/gremlin/translation/ir/rewrite/GroupStepFiltersTest.scala
@@ -16,9 +16,9 @@
 package org.opencypher.gremlin.translation.ir.rewrite
 
 import org.apache.tinkerpop.gremlin.structure.VertexProperty.Cardinality.single
-import org.junit.Test
+import org.junit.{Ignore, Test}
 import org.opencypher.gremlin.translation.CypherAst.parse
-import org.opencypher.gremlin.translation.Tokens.UNNAMED
+import org.opencypher.gremlin.translation.Tokens.{NULL, UNNAMED}
 import org.opencypher.gremlin.translation.ir.helpers.CypherAstAssert.{P, __}
 import org.opencypher.gremlin.translation.ir.helpers.CypherAstAssertions.assertThat
 import org.opencypher.gremlin.translation.translator.TranslatorFlavor
@@ -40,7 +40,7 @@ class GroupStepFiltersTest {
       """.stripMargin))
       .withFlavor(flavor)
       .rewritingWith(GroupStepFilters)
-      .removes(__.where(__.select("n").hasLabel("N")))
+      .removes(__.where(__.select("n").hasLabel("N").is(P.neq(NULL))))
       .keeps(__.hasLabel("N"))
   }
 
@@ -52,7 +52,7 @@ class GroupStepFiltersTest {
       """.stripMargin))
       .withFlavor(flavor)
       .rewritingWith(GroupStepFilters)
-      .removes(__.where(__.select("n").hasLabel("A").hasLabel("B")))
+      .removes(__.where(__.select("n").hasLabel("A").hasLabel("B").is(P.neq(NULL))))
       .keeps(__.hasLabel("A"))
       .keeps(__.hasLabel("B"))
   }
@@ -66,15 +66,16 @@ class GroupStepFiltersTest {
       """.stripMargin))
       .withFlavor(flavor)
       .rewritingWith(GroupStepFilters)
-      .removes(
-        __.where(
-          __.and(
-            __.select("n").values("p").is(P.isEq("n")),
-            __.constant(1).is(P.neq(2))
-          )))
+      .removes(__.where(__.and(
+        __.select("n")
+          .choose(__.values("p"), __.values("p"), __.constant(NULL))
+          .choose(P.neq(NULL), __.is(P.isEq("n")))
+          .is(P.neq(NULL)),
+        __.constant(1).choose(P.neq(NULL), __.is(P.neq(2))).is(P.neq(NULL))
+      )))
       .adds(
         __.has("p", P.isEq("n"))
-          .where(__.constant(1).is(P.neq(2)))
+          .where(__.constant(1).choose(P.neq(NULL), __.is(P.neq(2))).is(P.neq(NULL)))
       )
   }
 
@@ -87,9 +88,18 @@ class GroupStepFiltersTest {
       """.stripMargin))
       .withFlavor(flavor)
       .rewritingWith(GroupStepFilters)
-      .removes(__.select("n").values("p").is(P.isEq("n")))
-      .removes(__.select("r").values("p").is(P.isEq("r")))
-      .removes(__.select("m").values("p").is(P.isEq("m")))
+      .removes(
+        __.select("n")
+          .choose(__.values("p"), __.values("p"), __.constant(NULL))
+          .choose(P.neq(NULL), __.is(P.isEq("n"))))
+      .removes(
+        __.select("r")
+          .choose(__.values("p"), __.values("p"), __.constant(NULL))
+          .choose(P.neq(NULL), __.is(P.isEq("r"))))
+      .removes(
+        __.select("m")
+          .choose(__.values("p"), __.values("p"), __.constant(NULL))
+          .choose(P.neq(NULL), __.is(P.isEq("m"))))
       .adds(__.hasLabel("N").has("p", P.isEq("n")))
       .adds(__.as("r").has("p", P.isEq("r")))
       .adds(__.hasLabel("M").has("p", P.isEq("m")))
@@ -104,9 +114,18 @@ class GroupStepFiltersTest {
       """.stripMargin))
       .withFlavor(flavor)
       .rewritingWith(GroupStepFilters)
-      .removes(__.select("n").values("p").is(P.isEq("n")))
-      .removes(__.select("r").values("p").is(P.isEq("r")))
-      .removes(__.select("m").values("p").is(P.isEq("m")))
+      .removes(
+        __.select("n")
+          .choose(__.values("p"), __.values("p"), __.constant(NULL))
+          .choose(P.neq(NULL), __.is(P.isEq("n"))))
+      .removes(
+        __.select("r")
+          .choose(__.values("p"), __.values("p"), __.constant(NULL))
+          .choose(P.neq(NULL), __.is(P.isEq("r"))))
+      .removes(
+        __.select("m")
+          .choose(__.values("p"), __.values("p"), __.constant(NULL))
+          .choose(P.neq(NULL), __.is(P.isEq("m"))))
       .adds(__.hasLabel("N").has("p", P.isEq("n")))
       .adds(__.as("r").has("p", P.isEq("r")))
       .adds(__.hasLabel("M").has("p", P.isEq("m")))
@@ -121,9 +140,18 @@ class GroupStepFiltersTest {
       """.stripMargin))
       .withFlavor(flavor)
       .rewritingWith(GroupStepFilters)
-      .removes(__.select("n").values("p").is(P.isEq("n")))
-      .removes(__.select("k").values("p").is(P.isEq("k")))
-      .removes(__.select("m").values("p").is(P.isEq("m")))
+      .removes(
+        __.select("n")
+          .choose(__.values("p"), __.values("p"), __.constant(NULL))
+          .choose(P.neq(NULL), __.is(P.isEq("n"))))
+      .removes(
+        __.select("k")
+          .choose(__.values("p"), __.values("p"), __.constant(NULL))
+          .choose(P.neq(NULL), __.is(P.isEq("k"))))
+      .removes(
+        __.select("m")
+          .choose(__.values("p"), __.values("p"), __.constant(NULL))
+          .choose(P.neq(NULL), __.is(P.isEq("m"))))
       .adds(__.as("n").hasLabel("N").has("p", P.isEq("n")))
       .adds(__.as("m").hasLabel("M").has("p", P.isEq("m")))
       .adds(__.as("k").hasLabel("K").has("p", P.isEq("k")))
@@ -137,12 +165,13 @@ class GroupStepFiltersTest {
       """.stripMargin))
       .withFlavor(flavor)
       .rewritingWith(GroupStepFilters)
-      .removes(
-        __.where(
-          __.and(
-            __.select("n").values("p").is(P.isEq("n")),
-            __.select("n").hasLabel("N")
-          )))
+      .removes(__.where(__.and(
+        __.select("n")
+          .choose(__.values("p"), __.values("p"), __.constant(NULL))
+          .choose(P.neq(NULL), __.is(P.isEq("n")))
+          .is(P.neq(NULL)),
+        __.select("n").hasLabel("N").is(P.neq(NULL))
+      )))
       .adds(__.as("n").hasLabel("N").has("p", P.isEq("n")))
   }
 
@@ -151,7 +180,12 @@ class GroupStepFiltersTest {
     assertThat(parse("MERGE (n:N {p: 'n'})"))
       .withFlavor(flavor)
       .rewritingWith(GroupStepFilters)
-      .removes(__.select("n").values("p").is(P.isEq("n")))
+      .removes(
+        __.where(
+          __.select("n")
+            .choose(__.values("p"), __.values("p"), __.constant(NULL))
+            .choose(P.neq(NULL), __.is(P.isEq("n")))
+            .is(P.neq(NULL))))
       .adds(__.as("n").has("p", P.isEq("n")))
   }
 
@@ -163,8 +197,8 @@ class GroupStepFiltersTest {
       """.stripMargin))
       .withFlavor(flavor)
       .rewritingWith(GroupStepFilters)
-      .adds(__.V().as(UNNAMED + 7).hasLabel("person").has("name", P.isEq("marko")))
-      .adds(__.inV().as(UNNAMED + 44).hasLabel("person").has("name", P.isEq("josh")))
+      .adds(__.V().as(UNNAMED + 7).hasLabel("person").is(P.neq(NULL)).has("name", P.isEq("marko")))
+      .adds(__.inV().as(UNNAMED + 44).hasLabel("person").is(P.neq(NULL)) has ("name", P.isEq("josh")))
   }
 
   @Test

--- a/translation/src/test/scala/org/opencypher/gremlin/translation/ir/rewrite/RemoveIdentityReselectTest.scala
+++ b/translation/src/test/scala/org/opencypher/gremlin/translation/ir/rewrite/RemoveIdentityReselectTest.scala
@@ -17,6 +17,7 @@ package org.opencypher.gremlin.translation.ir.rewrite
 
 import org.junit.Test
 import org.opencypher.gremlin.translation.CypherAst.parse
+import org.opencypher.gremlin.translation.Tokens.NULL
 import org.opencypher.gremlin.translation.ir.helpers.CypherAstAssert._
 import org.opencypher.gremlin.translation.ir.helpers.CypherAstAssertions.assertThat
 import org.opencypher.gremlin.translation.translator.TranslatorFlavor
@@ -53,8 +54,23 @@ class RemoveIdentityReselectTest {
       """.stripMargin))
       .withFlavor(flavor)
       .rewritingWith(RemoveIdentityReselect)
-      .removes(__.as("n").hasLabel("L").has("foo", P.isEq("bar")).select("n"))
-      .keeps(__.as("n").hasLabel("L").has("foo", P.isEq("bar")))
+      .removes(
+        __.as("n")
+          .hasLabel("L")
+          .is(P.neq(NULL))
+          .has("foo", P.isEq("bar"))
+          .hasLabel("L")
+          .is(P.neq(NULL))
+          .has("foo", P.isEq("bar"))
+          .select("n"))
+      .keeps(
+        __.as("n")
+          .hasLabel("L")
+          .is(P.neq(NULL))
+          .has("foo", P.isEq("bar"))
+          .hasLabel("L")
+          .is(P.neq(NULL))
+          .has("foo", P.isEq("bar")))
   }
 
 }


### PR DESCRIPTION
- Return NULL in wrong predicate type
- Handle NULL in where conditions
- Fix bug when string predicates were not recognized as `WHERE` conditions
- `Choose` case class variations to simplify code in rewriters

TCK +7

Signed-off-by: Dwitry dwitry@users.noreply.github.com