### PR TITLE
Only aliases in `WITH` are bound:

### DIFF
--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/WithTest.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/WithTest.java
@@ -232,4 +232,21 @@ public class WithTest {
             .extracting("p.name")
             .containsExactly("josh");
     }
+
+    @Test
+    public void onlyAliasesInWithAreBound() {
+        List<Map<String, Object>> results = submitAndGet(
+            "MATCH (unbound:person {name: 'marko'})-[:created]->(bound:software {name: 'lop'})" +
+                "WITH bound " +
+                "MATCH (unbound)-[:created]->(bound)" +
+                "RETURN unbound.name, bound.name"
+        );
+
+        assertThat(results)
+            .extracting("unbound.name", "bound.name")
+            .containsExactlyInAnyOrder(
+                tuple("josh", "lop"),
+                tuple("peter", "lop"),
+                tuple("marko", "lop"));
+    }
 }

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/context/WalkerContext.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/context/WalkerContext.scala
@@ -104,6 +104,10 @@ sealed class WalkerContext[T, P](
     }
   }
 
+  def clearAliases() = {
+    referencedAliases.clear()
+  }
+
   private var nameGenerator = new NameGenerator()
 
   def generateName(): String = {

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/walker/ProjectionWalker.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/walker/ProjectionWalker.scala
@@ -83,6 +83,7 @@ private class ProjectionWalker[T, P](context: WalkerContext[T, P], g: GremlinSte
     applyWhereFromReturnItems(items)
     walk(distinct, items, orderBy, skip, limit)
     applyWhere(where)
+    context.clearAliases()
     reselectProjection(items)
   }
 


### PR DESCRIPTION
- When selecting alias not defined in `WITH` don't match aliases defined before `WITH`
- Clear aliases before rebinding in `reselectProjection`

TCK +1

Signed-off-by: Dwitry dwitry@users.noreply.github.com