### PR TITLE
Cosmos DB improvements

### DIFF
--- a/translation/src/main/scala/org/opencypher/gremlin/translation/ir/TranslationWriter.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/ir/TranslationWriter.scala
@@ -96,17 +96,13 @@ sealed class TranslationWriter[T, P] private (translator: Translator[T, P], para
             .getOrElse(g.by(writeLocalSteps(traversal)))
         case Cap(sideEffectKey) =>
           g.cap(sideEffectKey)
-        case ChooseT(choiceTraversal, None, None) =>
+        case ChooseT1(choiceTraversal) =>
           g.choose(writeLocalSteps(choiceTraversal))
-        case c @ ChooseT(_, None, Some(_)) =>
-          throw new UnsupportedOperationException(s"Unsupported $c")
-        case c @ ChooseT(_, Some(_), None) =>
-          throw new UnsupportedOperationException(s"Unsupported $c")
-        case ChooseT(traversalPredicate, Some(trueChoice), Some(falseChoice)) =>
+        case ChooseT3(traversalPredicate, trueChoice, falseChoice) =>
           g.choose(writeLocalSteps(traversalPredicate), writeLocalSteps(trueChoice), writeLocalSteps(falseChoice))
-        case ChooseP(predicate, trueChoice, None) =>
+        case ChooseP2(predicate, trueChoice) =>
           g.choose(writePredicate(predicate), writeLocalSteps(trueChoice))
-        case ChooseP(predicate, trueChoice, Some(falseChoice)) =>
+        case ChooseP3(predicate, trueChoice, falseChoice) =>
           g.choose(writePredicate(predicate), writeLocalSteps(trueChoice), writeLocalSteps(falseChoice))
         case Coalesce(coalesceTraversals @ _*) =>
           g.coalesce(coalesceTraversals.map(writeLocalSteps): _*)

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/ir/builder/IRGremlinSteps.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/ir/builder/IRGremlinSteps.scala
@@ -103,7 +103,7 @@ class IRGremlinSteps extends GremlinSteps[Seq[GremlinStep], GremlinPredicate] {
 
   override def choose(choiceTraversal: GremlinSteps[Seq[GremlinStep], GremlinPredicate])
     : GremlinSteps[Seq[GremlinStep], GremlinPredicate] = {
-    buf += ChooseT(choiceTraversal.current())
+    buf += ChooseT1(choiceTraversal.current())
     this
   }
 
@@ -112,7 +112,7 @@ class IRGremlinSteps extends GremlinSteps[Seq[GremlinStep], GremlinPredicate] {
       trueChoice: GremlinSteps[Seq[GremlinStep], GremlinPredicate],
       falseChoice: GremlinSteps[Seq[GremlinStep], GremlinPredicate])
     : GremlinSteps[Seq[GremlinStep], GremlinPredicate] = {
-    buf += ChooseT(traversalPredicate.current(), Some(trueChoice.current()), Some(falseChoice.current()))
+    buf += ChooseT3(traversalPredicate.current(), trueChoice.current(), falseChoice.current())
     this
   }
 
@@ -121,13 +121,13 @@ class IRGremlinSteps extends GremlinSteps[Seq[GremlinStep], GremlinPredicate] {
       trueChoice: GremlinSteps[Seq[GremlinStep], GremlinPredicate],
       falseChoice: GremlinSteps[Seq[GremlinStep], GremlinPredicate])
     : GremlinSteps[Seq[GremlinStep], GremlinPredicate] = {
-    buf += ChooseP(predicate, trueChoice.current(), Some(falseChoice.current()))
+    buf += ChooseP3(predicate, trueChoice.current(), falseChoice.current())
     this
   }
 
   override def choose(predicate: GremlinPredicate, trueChoice: GremlinSteps[Seq[GremlinStep], GremlinPredicate])
     : GremlinSteps[Seq[GremlinStep], GremlinPredicate] = {
-    buf += ChooseP(predicate, trueChoice.current())
+    buf += ChooseP2(predicate, trueChoice.current())
     this
   }
 

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/CustomFunctionFallback.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/CustomFunctionFallback.scala
@@ -38,7 +38,7 @@ object CustomFunctionFallback extends GremlinRewriter {
         Path :: From(text) :: rest
 
       case SelectC(values) :: MapF(function) :: rest if function.getName == cypherPlus().getName =>
-        SelectC(values) :: Local(Unfold :: ChooseP(Neq(NULL), Sum :: Nil, None) :: Nil) :: rest
+        SelectC(values) :: Local(Unfold :: ChooseP2(Neq(NULL), Sum :: Nil) :: Nil) :: rest
 
       case MapF(function) :: rest if function.getName == cypherSize().getName =>
         CountS(local) :: rest

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/RemoveUselessNullChecks.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/RemoveUselessNullChecks.scala
@@ -37,10 +37,10 @@ object RemoveUselessNullChecks extends GremlinRewriter {
 
   private def splitSegment(steps: Seq[GremlinStep]): (Seq[GremlinStep], Seq[GremlinStep]) = {
     val (segment, rest) = steps.span {
-      case By(SelectK(_) :: ChooseP(Neq(NULL), _, None) :: Nil, None) => false
-      case By(ChooseP(Neq(NULL), _, None) :: Nil, None)               => false
-      case ChooseP(Neq(NULL), _, None)                                => false
-      case _                                                          => true
+      case By(SelectK(_) :: ChooseP2(Neq(NULL), _) :: Nil, None) => false
+      case By(ChooseP2(Neq(NULL), _) :: Nil, None)               => false
+      case ChooseP2(Neq(NULL), _)                                => false
+      case _                                                     => true
     }
     rest match {
       case head :: tail => (segment :+ head, tail)
@@ -62,11 +62,11 @@ object RemoveUselessNullChecks extends GremlinRewriter {
     }
 
     val last = steps.last match {
-      case By(SelectK(key) :: ChooseP(Neq(NULL), traversal, None) :: Nil, None) =>
+      case By(SelectK(key) :: ChooseP2(Neq(NULL), traversal) :: Nil, None) =>
         By(SelectK(key) +: traversal, None) :: Nil
-      case By(ChooseP(Neq(NULL), traversal, None) :: Nil, None) =>
+      case By(ChooseP2(Neq(NULL), traversal) :: Nil, None) =>
         By(traversal, None) :: Nil
-      case ChooseP(Neq(NULL), traversal, None) =>
+      case ChooseP2(Neq(NULL), traversal) =>
         traversal
       case step =>
         step :: Nil

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/SimplifyDelete.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/SimplifyDelete.scala
@@ -26,7 +26,7 @@ object SimplifyDelete extends GremlinRewriter {
   def apply(steps: Seq[GremlinStep]): Seq[GremlinStep] = {
     val withChoose = foldTraversals(false)((acc, localSteps) => {
       acc || extract({
-        case ChooseP(IsNode(), Aggregate(DELETE) :: Nil, Some(Aggregate(DETACH_DELETE) :: Nil)) :: _ => true
+        case ChooseP3(IsNode(), Aggregate(DELETE) :: Nil, Aggregate(DETACH_DELETE) :: Nil) :: _ => true
       })(localSteps).contains(true)
     })(steps)
 

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/SimplifyPropertySetters.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/SimplifyPropertySetters.scala
@@ -33,7 +33,7 @@ object SimplifyPropertySetters extends GremlinRewriter {
         PropertyV(key, value) :: rest
       case PropertyTC(cardinality, key, Constant(value) :: Nil) :: rest =>
         PropertyVC(cardinality, key, value) :: rest
-      case ChooseT(_, Some(PropertyV(key, value) :: Nil), Some(drop)) :: rest =>
+      case ChooseT3(_, PropertyV(key, value) :: Nil, drop) :: rest =>
         val empty = value match {
           case NULL                     => true
           case coll: util.Collection[_] => coll.isEmpty
@@ -44,7 +44,7 @@ object SimplifyPropertySetters extends GremlinRewriter {
         } else {
           PropertyV(key, value) :: rest
         }
-      case step @ ChooseT(_, Some(prop @ PropertyT(_, Project(_*) :: valueTail) :: Nil), _) :: rest
+      case step @ ChooseT3(_, prop @ PropertyT(_, Project(_*) :: valueTail) :: Nil, _) :: rest
           if valueTail.init.forall(_.isInstanceOf[By]) =>
         valueTail.last match {
           case _: By | _: SelectC => prop ++ rest

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/ir/verify/NoCustomFunctions.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/ir/verify/NoCustomFunctions.scala
@@ -41,10 +41,10 @@ object NoCustomFunctions extends GremlinPostCondition {
     })(steps)
 
     val predicates = extract({
-      case ChooseP(predicate, _, _) :: _ => predicate
-      case HasP(_, predicate) :: _       => predicate
-      case Is(predicate) :: _            => predicate
-      case WhereP(predicate) :: _        => predicate
+      case ChooseP3(predicate, _, _) :: _ => predicate
+      case HasP(_, predicate) :: _        => predicate
+      case Is(predicate) :: _             => predicate
+      case WhereP(predicate) :: _         => predicate
     })(steps)
       .flatMap({
         case _: StartsWith => Some("cypherStarsWith")

--- a/translation/src/test/scala/org/opencypher/gremlin/translation/ir/rewrite/NeptuneFlavorTest.scala
+++ b/translation/src/test/scala/org/opencypher/gremlin/translation/ir/rewrite/NeptuneFlavorTest.scala
@@ -18,15 +18,12 @@ package org.opencypher.gremlin.translation.ir.rewrite
 import org.apache.tinkerpop.gremlin.process.traversal.Order
 import org.junit.Test
 import org.opencypher.gremlin.translation.CypherAst.parse
-import org.opencypher.gremlin.translation.{GremlinSteps, Tokens}
+import org.opencypher.gremlin.translation.Tokens
 import org.opencypher.gremlin.translation.Tokens._
-import org.opencypher.gremlin.translation.context.WalkerContext
 import org.opencypher.gremlin.translation.ir.helpers.CypherAstAssert.{P, __}
 import org.opencypher.gremlin.translation.ir.helpers.CypherAstAssertions.assertThat
-import org.opencypher.gremlin.translation.translator.{Translator, TranslatorFlavor}
-import org.opencypher.gremlin.translation.traversal.DeprecatedOrderAccessor
+import org.opencypher.gremlin.translation.translator.TranslatorFlavor
 import org.opencypher.gremlin.translation.traversal.DeprecatedOrderAccessor.{decr, incr}
-import org.opencypher.gremlin.translation.walker.NodeUtils
 
 class NeptuneFlavorTest {
 


### PR DESCRIPTION
- Rewrite `choose(a, b)` → `choose(a, b, identity()`
- In TinkerPop 3.3.4 order `desc`/`incr` deprecated in favor of `asc`/`desc`. Because its not available in Cosmos DB - fallback to deprecated values

Signed-off-by: Dwitry dwitry@users.noreply.github.com