### PR TITLE
Integration test refactoring

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -231,6 +231,8 @@ project(':testware:integration-tests') {
         systemProperty 'translate', System.getProperty('translate')
         systemProperty 'configPath', System.getProperty('configPath')
 
+        exclude "**/suites/**"
+
         if (System.getProperty('excludeCategories')!=null) {
             useJUnit {
                 excludeCategories System.getProperty('excludeCategories').split(",")
@@ -240,6 +242,8 @@ project(':testware:integration-tests') {
 
     task('testGremlinGroovyTranslation', type: Test) {
         systemProperty 'translate', 'gremlin'
+
+        exclude "**/suites/**"
 
         if (project.hasProperty('ci')) {
             testLogging.showStandardStreams = true
@@ -256,6 +260,8 @@ project(':testware:integration-tests') {
 
     task('testBytecodeTranslation', type: Test) {
         systemProperty 'translate', 'bytecode'
+
+        exclude "**/suites/**"
 
         if (project.hasProperty('ci')) {
             testLogging.showStandardStreams = true

--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/client/BytecodeCypherGremlinClientTest.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/client/BytecodeCypherGremlinClientTest.java
@@ -25,13 +25,14 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.opencypher.gremlin.rules.GremlinServerExternalResource;
+import org.opencypher.gremlin.test.TestCommons;
 import org.opencypher.gremlin.translation.translator.Translator;
 
 @SuppressWarnings("Duplicates")
 public class BytecodeCypherGremlinClientTest {
 
     @ClassRule
-    public static final GremlinServerExternalResource gremlinServer = new GremlinServerExternalResource();
+    public static final GremlinServerExternalResource gremlinServer = new GremlinServerExternalResource(TestCommons::modernGraph);
 
     private BytecodeCypherGremlinClient client;
 

--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/client/GroovyCypherGremlinClientTest.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/client/GroovyCypherGremlinClientTest.java
@@ -25,13 +25,14 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.opencypher.gremlin.rules.GremlinServerExternalResource;
+import org.opencypher.gremlin.test.TestCommons;
 import org.opencypher.gremlin.translation.translator.Translator;
 
 @SuppressWarnings("Duplicates")
 public class GroovyCypherGremlinClientTest {
 
     @ClassRule
-    public static final GremlinServerExternalResource gremlinServer = new GremlinServerExternalResource();
+    public static final GremlinServerExternalResource gremlinServer = new GremlinServerExternalResource(TestCommons::modernGraph);
 
     private GroovyCypherGremlinClient client;
 

--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/client/OpProcessorCypherGremlinClientTest.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/client/OpProcessorCypherGremlinClientTest.java
@@ -25,11 +25,12 @@ import org.apache.tinkerpop.gremlin.driver.Client;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.opencypher.gremlin.rules.GremlinServerExternalResource;
+import org.opencypher.gremlin.test.TestCommons;
 
 public class OpProcessorCypherGremlinClientTest {
 
     @ClassRule
-    public static final GremlinServerExternalResource gremlinServer = new GremlinServerExternalResource();
+    public static final GremlinServerExternalResource gremlinServer = new GremlinServerExternalResource(TestCommons::modernGraph);
 
     @Test
     public void submitToDefaultGraph() {

--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/neo4jadapter/GremlinNeo4jDriverTest.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/neo4jadapter/GremlinNeo4jDriverTest.java
@@ -15,7 +15,6 @@
  */
 package org.opencypher.gremlin.neo4jadapter;
 
-import static java.util.Collections.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.neo4j.driver.v1.Values.parameters;
@@ -37,11 +36,12 @@ import org.neo4j.driver.v1.types.Relationship;
 import org.opencypher.gremlin.neo4j.driver.Config;
 import org.opencypher.gremlin.neo4j.driver.GremlinDatabase;
 import org.opencypher.gremlin.rules.GremlinServerExternalResource;
+import org.opencypher.gremlin.test.TestCommons;
 import org.opencypher.gremlin.translation.translator.TranslatorFlavor;
 
 public class GremlinNeo4jDriverTest {
     @ClassRule
-    public static final GremlinServerExternalResource server = new GremlinServerExternalResource();
+    public static final GremlinServerExternalResource server = new GremlinServerExternalResource(TestCommons::modernGraph);
 
     @Test
     public void simple() {

--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/CaseTest.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/CaseTest.java
@@ -24,11 +24,12 @@ import java.util.Map;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.opencypher.gremlin.rules.GremlinServerExternalResource;
+import org.opencypher.gremlin.test.TestCommons;
 
 public class CaseTest {
 
     @ClassRule
-    public static final GremlinServerExternalResource gremlinServer = new GremlinServerExternalResource();
+    public static final GremlinServerExternalResource gremlinServer = new GremlinServerExternalResource(TestCommons::modernGraph);
 
     private List<Map<String, Object>> submitAndGet(String cypher) {
         return gremlinServer.cypherGremlinClient().submit(cypher).all();

--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/ComparisonTest.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/ComparisonTest.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.opencypher.gremlin.rules.GremlinServerExternalResource;
+import org.opencypher.gremlin.test.TestCommons;
 
 public class ComparisonTest {
 
@@ -30,7 +31,7 @@ public class ComparisonTest {
     private static final String[] EVERYONE = new String[]{"marko", "vadas", "josh", "peter"};
 
     @ClassRule
-    public static final GremlinServerExternalResource gremlinServer = new GremlinServerExternalResource();
+    public static final GremlinServerExternalResource gremlinServer = new GremlinServerExternalResource(TestCommons::modernGraph);
 
     private List<Map<String, Object>> submitAndGet(String cypher) {
         return gremlinServer.cypherGremlinClient().submit(cypher).all();

--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/ComplexExamplesTest.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/ComplexExamplesTest.java
@@ -297,7 +297,7 @@ public class ComplexExamplesTest {
 
         assertThat(results)
             .extracting("n.name", "x.name")
-            .containsExactly(tuple("house1", "house3"),
+            .containsExactlyInAnyOrder(tuple("house1", "house3"),
                 tuple("house1", "house4"));
     }
 

--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/ContainerIndexTest.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/ContainerIndexTest.java
@@ -27,7 +27,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
-import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -38,11 +37,6 @@ public class ContainerIndexTest {
 
     @ClassRule
     public static final GremlinServerExternalResource gremlinServer = new GremlinServerExternalResource();
-
-    @Before
-    public void setUp() {
-        gremlinServer.gremlinClient().submit("g.V().drop()").all().join();
-    }
 
     private List<Map<String, Object>> submitAndGet(String cypher) {
         return submitAndGet(cypher, emptyMap());

--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/DeleteTest.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/DeleteTest.java
@@ -22,16 +22,18 @@ import static org.opencypher.gremlin.test.TestCommons.parameterMap;
 
 import java.util.List;
 import java.util.Map;
-import org.junit.Rule;
+import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.opencypher.gremlin.groups.WithCustomPredicates;
 import org.opencypher.gremlin.rules.GremlinServerExternalResource;
+import org.opencypher.gremlin.test.TestCommons;
 
 public class DeleteTest {
 
-    @Rule
-    public final GremlinServerExternalResource gremlinServer = new GremlinServerExternalResource();
+    @ClassRule
+    public static final GremlinServerExternalResource gremlinServer = new GremlinServerExternalResource(TestCommons::modernGraph);
 
     private List<Map<String, Object>> submitAndGet(String cypher) {
         return gremlinServer.cypherGremlinClient().submit(cypher).all();
@@ -39,6 +41,11 @@ public class DeleteTest {
 
     private List<Map<String, Object>> submitAndGet(String cypher, Object... parameters) {
         return gremlinServer.cypherGremlinClient().submit(cypher, parameterMap(parameters)).all();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        TestCommons.modernGraph(gremlinServer.cypherGremlinClient());
     }
 
     @Test

--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/FunctionTest.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/FunctionTest.java
@@ -29,11 +29,12 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.opencypher.gremlin.groups.WithCustomFunctions;
 import org.opencypher.gremlin.rules.GremlinServerExternalResource;
+import org.opencypher.gremlin.test.TestCommons;
 
 public class FunctionTest {
 
     @ClassRule
-    public static final GremlinServerExternalResource gremlinServer = new GremlinServerExternalResource();
+    public static final GremlinServerExternalResource gremlinServer = new GremlinServerExternalResource(TestCommons::modernGraph);
 
     private List<Map<String, Object>> submitAndGet(String cypher) {
         return gremlinServer.cypherGremlinClient().submit(cypher).all();
@@ -303,7 +304,7 @@ public class FunctionTest {
 
         assertThat(results)
             .extracting("n.name")
-            .containsExactly("marko", "josh");
+            .containsExactlyInAnyOrder("marko", "josh");
     }
 
     @Test
@@ -397,16 +398,16 @@ public class FunctionTest {
     @Category(WithCustomFunctions.class)
     public void invalidArgumentInStringFunctions() {
         assertThatThrownBy(() -> submitAndGet("MATCH (n {name: 'marko'}) RETURN tolower(n.age)"))
-                        .hasMessageContaining("Expected a String value for <function1>, but got: Integer(29)");
+                        .hasMessageContaining("Expected a String value for <function1>, but got:");
 
         assertThatThrownBy(() -> submitAndGet("MATCH (n {name: 'marko'}) RETURN split(n.age, '1')"))
-                        .hasMessageContaining("Expected a String value for <function1>, but got: Integer(29)");
+                        .hasMessageContaining("Expected a String value for <function1>, but got:");
 
         assertThatThrownBy(() -> submitAndGet("MATCH (n {name: 'marko'}) RETURN split('word', n.age)"))
-                        .hasMessageContaining("Expected a String value for <function1>, but got: Integer(29)");
+                        .hasMessageContaining("Expected a String value for <function1>, but got:");
 
         assertThatThrownBy(() -> submitAndGet("MATCH (n {name: 'marko'}) RETURN reverse(n.age)"))
-                        .hasMessageContaining("Expected a string or list value for reverse, but got: Integer(29)");
+                        .hasMessageContaining("Expected a string or list value for reverse, but got:");
     }
 
     @Test

--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/ListComprehensionTest.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/ListComprehensionTest.java
@@ -17,6 +17,7 @@ package org.opencypher.gremlin.queries;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.opencypher.gremlin.test.TestCommons.ignoreOrderInCollections;
 import static org.opencypher.gremlin.translation.ReturnProperties.LABEL;
 
 import java.util.Collection;
@@ -104,6 +105,7 @@ public class ListComprehensionTest {
         assertThat(results)
             .hasSize(1)
             .extracting("years")
+            .usingElementComparator(ignoreOrderInCollections())
             .containsExactly(asList(1987L, 1979L, 1984L));
     }
 

--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/MatchTest.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/MatchTest.java
@@ -18,23 +18,26 @@ package org.opencypher.gremlin.queries;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.opencypher.gremlin.test.GremlinExtractors.byElementProperty;
-import static org.opencypher.gremlin.test.TestCommons.JOSH;
-import static org.opencypher.gremlin.test.TestCommons.LOP;
-import static org.opencypher.gremlin.test.TestCommons.MARKO;
-import static org.opencypher.gremlin.test.TestCommons.PETER;
-import static org.opencypher.gremlin.test.TestCommons.RIPPLE;
-import static org.opencypher.gremlin.test.TestCommons.VADAS;
 
 import java.util.List;
 import java.util.Map;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.opencypher.gremlin.rules.GremlinServerExternalResource;
+import org.opencypher.gremlin.test.TestCommons;
+import org.opencypher.gremlin.test.TestCommons.ModernGraph;
 
 public class MatchTest {
-
     @ClassRule
     public static final GremlinServerExternalResource gremlinServer = new GremlinServerExternalResource();
+
+    public static ModernGraph g;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        g = TestCommons.modernGraph(gremlinServer.cypherGremlinClient());
+    }
 
     private List<Map<String, Object>> submitAndGet(String cypher) {
         return gremlinServer.cypherGremlinClient().submit(cypher).all();
@@ -48,7 +51,7 @@ public class MatchTest {
 
         assertThat(results)
             .extracting("n")
-            .containsExactlyInAnyOrder(MARKO, VADAS, JOSH, PETER, LOP, RIPPLE);
+            .containsExactlyInAnyOrder(g.MARKO, g.VADAS, g.JOSH, g.PETER, g.LOP, g.RIPPLE);
     }
 
     @Test
@@ -167,7 +170,7 @@ public class MatchTest {
 
         assertThat(results)
             .extracting("m")
-            .containsExactly(MARKO);
+            .containsExactly(g.MARKO);
     }
 
     @Test

--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/MergeTest.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/MergeTest.java
@@ -195,7 +195,7 @@ public class MergeTest {
 
     @Test
     public void vertexOn() throws Exception {
-        String query = "MERGE (a:Label {prop: 'value'}) " +
+        String query = "MERGE (a:lbl {prop: 'value'}) " +
             "ON MATCH SET a.action = 'on match' " +
             "ON CREATE SET a.action = 'on create' " +
             "RETURN a.action, a.prop, labels(a)";
@@ -204,7 +204,7 @@ public class MergeTest {
         List<Map<String, Object>> results = submitAndGet(query);
         assertThat(results)
             .extracting("a.prop", "labels(a)")
-            .containsExactly(tuple("value", singletonList("Label")));
+            .containsExactly(tuple("value", singletonList("lbl")));
 
         // checking SET clause
         assertThat(results)

--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/OptionalMatchTest.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/OptionalMatchTest.java
@@ -19,29 +19,26 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
-import static org.opencypher.gremlin.test.TestCommons.JOSH;
-import static org.opencypher.gremlin.test.TestCommons.JOSH_CREATED_LOP;
-import static org.opencypher.gremlin.test.TestCommons.JOSH_CREATED_RIPPLE;
-import static org.opencypher.gremlin.test.TestCommons.LOP;
-import static org.opencypher.gremlin.test.TestCommons.MARKO;
-import static org.opencypher.gremlin.test.TestCommons.MARKO_CREATED_LOP;
-import static org.opencypher.gremlin.test.TestCommons.MARKO_KNOWS_JOSH;
-import static org.opencypher.gremlin.test.TestCommons.MARKO_KNOWS_VADAS;
-import static org.opencypher.gremlin.test.TestCommons.PETER;
-import static org.opencypher.gremlin.test.TestCommons.PETER_CREATED_LOP;
-import static org.opencypher.gremlin.test.TestCommons.RIPPLE;
-import static org.opencypher.gremlin.test.TestCommons.VADAS;
 
 import java.util.List;
 import java.util.Map;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.opencypher.gremlin.rules.GremlinServerExternalResource;
+import org.opencypher.gremlin.test.TestCommons;
+import org.opencypher.gremlin.test.TestCommons.ModernGraph;
 
 public class OptionalMatchTest {
-
     @ClassRule
     public static final GremlinServerExternalResource gremlinServer = new GremlinServerExternalResource();
+
+    public static ModernGraph g;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        g = TestCommons.modernGraph(gremlinServer.cypherGremlinClient());
+    }
 
     private List<Map<String, Object>> submitAndGet(String cypher) {
         return gremlinServer.cypherGremlinClient().submit(cypher).all();
@@ -84,12 +81,12 @@ public class OptionalMatchTest {
         assertThat(results)
             .extracting("p")
             .containsExactlyInAnyOrder(
-                asList(MARKO, MARKO_KNOWS_VADAS, VADAS),
-                asList(MARKO, MARKO_KNOWS_JOSH, JOSH),
-                asList(MARKO, MARKO_CREATED_LOP, LOP),
-                asList(JOSH, JOSH_CREATED_RIPPLE, RIPPLE),
-                asList(JOSH, JOSH_CREATED_LOP, LOP),
-                asList(PETER, PETER_CREATED_LOP, LOP)
+                asList(g.MARKO, g.MARKO_KNOWS_VADAS, g.VADAS),
+                asList(g.MARKO, g.MARKO_KNOWS_JOSH, g.JOSH),
+                asList(g.MARKO, g.MARKO_CREATED_LOP, g.LOP),
+                asList(g.JOSH, g.JOSH_CREATED_RIPPLE, g.RIPPLE),
+                asList(g.JOSH, g.JOSH_CREATED_LOP, g.LOP),
+                asList(g.PETER, g.PETER_CREATED_LOP, g.LOP)
             );
     }
 

--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/OrderByTest.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/OrderByTest.java
@@ -23,11 +23,12 @@ import java.util.Map;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.opencypher.gremlin.rules.GremlinServerExternalResource;
+import org.opencypher.gremlin.test.TestCommons;
 
 public class OrderByTest {
 
     @ClassRule
-    public static final GremlinServerExternalResource gremlinServer = new GremlinServerExternalResource();
+    public static final GremlinServerExternalResource gremlinServer = new GremlinServerExternalResource(TestCommons::modernGraph);
 
     private static final int VERTICES_COUNT = 6;
 

--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/ParameterTest.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/ParameterTest.java
@@ -27,11 +27,12 @@ import org.junit.experimental.categories.Category;
 import org.opencypher.gremlin.groups.WithCustomFunctions;
 import org.opencypher.gremlin.groups.WithCustomPredicates;
 import org.opencypher.gremlin.rules.GremlinServerExternalResource;
+import org.opencypher.gremlin.test.TestCommons;
 
 public class ParameterTest {
 
     @ClassRule
-    public static final GremlinServerExternalResource gremlinServer = new GremlinServerExternalResource();
+    public static final GremlinServerExternalResource gremlinServer = new GremlinServerExternalResource(TestCommons::modernGraph);
 
     private List<Map<String, Object>> submitAndGet(String cypher, Map<String, ?> parameters) {
         return gremlinServer.cypherGremlinClient().submit(cypher, parameters).all();

--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/ReturnTest.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/ReturnTest.java
@@ -20,34 +20,32 @@ import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
-import static org.opencypher.gremlin.test.TestCommons.JOSH;
-import static org.opencypher.gremlin.test.TestCommons.JOSH_CREATED_LOP;
-import static org.opencypher.gremlin.test.TestCommons.JOSH_CREATED_RIPPLE;
-import static org.opencypher.gremlin.test.TestCommons.LOP;
-import static org.opencypher.gremlin.test.TestCommons.MARKO;
-import static org.opencypher.gremlin.test.TestCommons.MARKO_CREATED_LOP;
-import static org.opencypher.gremlin.test.TestCommons.MARKO_KNOWS_JOSH;
-import static org.opencypher.gremlin.test.TestCommons.PETER;
-import static org.opencypher.gremlin.test.TestCommons.PETER_CREATED_LOP;
-import static org.opencypher.gremlin.test.TestCommons.RIPPLE;
-import static org.opencypher.gremlin.test.TestCommons.VADAS;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.opencypher.gremlin.groups.WithCustomFunctions;
 import org.opencypher.gremlin.groups.WithCustomPredicates;
 import org.opencypher.gremlin.rules.GremlinServerExternalResource;
+import org.opencypher.gremlin.test.TestCommons;
+import org.opencypher.gremlin.test.TestCommons.ModernGraph;
 
 public class ReturnTest {
-
     @ClassRule
     public static final GremlinServerExternalResource gremlinServer = new GremlinServerExternalResource();
+
+    public static ModernGraph g;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        g = TestCommons.modernGraph(gremlinServer.cypherGremlinClient());
+    }
 
     private List<Map<String, Object>> submitAndGet(String cypher) {
         return submitAndGet(cypher, emptyMap());
@@ -185,10 +183,10 @@ public class ReturnTest {
         assertThat(results)
             .extracting("p")
             .containsExactlyInAnyOrder(
-                asList(MARKO, MARKO_CREATED_LOP, LOP),
-                asList(JOSH, JOSH_CREATED_RIPPLE, RIPPLE),
-                asList(JOSH, JOSH_CREATED_LOP, LOP),
-                asList(PETER, PETER_CREATED_LOP, LOP)
+                asList(g.MARKO, g.MARKO_CREATED_LOP,   g.LOP),
+                asList(g.JOSH,  g.JOSH_CREATED_RIPPLE, g.RIPPLE),
+                asList(g.JOSH,  g.JOSH_CREATED_LOP,    g.LOP),
+                asList(g.PETER, g.PETER_CREATED_LOP,   g.LOP)
             );
     }
 
@@ -200,10 +198,10 @@ public class ReturnTest {
         assertThat(results)
             .extracting("p")
             .containsExactlyInAnyOrder(
-                asList(MARKO, MARKO_CREATED_LOP, LOP),
-                asList(JOSH, JOSH_CREATED_RIPPLE, RIPPLE),
-                asList(JOSH, JOSH_CREATED_LOP, LOP),
-                asList(PETER, PETER_CREATED_LOP, LOP)
+                asList(g. MARKO, g.MARKO_CREATED_LOP,   g.LOP),
+                asList(g. JOSH,  g.JOSH_CREATED_RIPPLE, g.RIPPLE),
+                asList(g. JOSH,  g.JOSH_CREATED_LOP,    g.LOP),
+                asList(g. PETER, g.PETER_CREATED_LOP,   g.LOP)
             );
     }
 
@@ -216,10 +214,10 @@ public class ReturnTest {
             .hasSize(4)
             .extracting("p")
             .containsExactlyInAnyOrder(
-                asList(MARKO),
-                asList(VADAS),
-                asList(JOSH),
-                asList(PETER)
+                asList(g.MARKO),
+                asList(g.VADAS),
+                asList(g.JOSH),
+                asList(g.PETER)
             );
     }
 
@@ -370,8 +368,8 @@ public class ReturnTest {
         assertThat(results)
             .extracting("r")
             .containsExactlyInAnyOrder(
-                asList(MARKO, VADAS),
-                asList(MARKO, JOSH)
+                asList(g.MARKO, g.VADAS),
+                asList(g.MARKO, g.JOSH)
             );
     }
 
@@ -385,8 +383,8 @@ public class ReturnTest {
         assertThat(results)
             .extracting("r", "n")
             .containsExactlyInAnyOrder(
-                tuple(asList(MARKO, VADAS), "marko"),
-                tuple(asList(MARKO, JOSH), "marko")
+                tuple(asList(g.MARKO, g.VADAS), "marko"),
+                tuple(asList(g.MARKO, g.JOSH), "marko")
             );
     }
 
@@ -401,8 +399,8 @@ public class ReturnTest {
         assertThat(results)
             .extracting("nodes", "rels")
             .containsExactlyInAnyOrder(
-                tuple(asList(MARKO, JOSH, LOP), asList(MARKO_KNOWS_JOSH, JOSH_CREATED_LOP)),
-                tuple(asList(MARKO, JOSH, RIPPLE), asList(MARKO_KNOWS_JOSH, JOSH_CREATED_RIPPLE))
+                tuple(asList(g.MARKO, g.JOSH, g.LOP), asList(g.MARKO_KNOWS_JOSH, g.JOSH_CREATED_LOP)),
+                tuple(asList(g.MARKO, g.JOSH, g.RIPPLE), asList(g.MARKO_KNOWS_JOSH, g.JOSH_CREATED_RIPPLE))
             );
     }
 
@@ -535,13 +533,13 @@ public class ReturnTest {
 
         List<Map<String, Object>> cypherResults = submitAndGet(cypher);
 
-        List<Map<String, Object>> markoCreatedOssPath = asList(MARKO, MARKO_CREATED_LOP, LOP);
+        List<Map<String, Object>> markoCreatedOssPath = asList(g.MARKO, g.MARKO_CREATED_LOP, g.LOP);
 
         assertThat(cypherResults)
             .extracting("n", "r", "p")
             .containsExactly(tuple(
-                asList(asList(asList(MARKO))),
-                asList(asList(asList(MARKO_CREATED_LOP))),
+                asList(asList(asList(g.MARKO))),
+                asList(asList(asList(g.MARKO_CREATED_LOP))),
                 asList(asList(asList(markoCreatedOssPath))))
             );
     }

--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/SetTest.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/SetTest.java
@@ -81,7 +81,7 @@ public class SetTest {
     }
 
     private List<Object> setAndGetProperty(String value) throws Exception {
-        String query = "MATCH (n) SET n.property = %s RETURN n.property AS prop LIMIT 1";
+        String query = "MATCH (n) SET n.property1 = %s RETURN n.property1 AS prop LIMIT 1";
         return submitAndGet(format(query, value)).stream().map(r -> r.get("prop")).collect(toList());
     }
 

--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/UnionTest.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/UnionTest.java
@@ -22,11 +22,12 @@ import java.util.Map;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.opencypher.gremlin.rules.GremlinServerExternalResource;
+import org.opencypher.gremlin.test.TestCommons;
 
 public class UnionTest {
 
     @ClassRule
-    public static final GremlinServerExternalResource gremlinServer = new GremlinServerExternalResource();
+    public static final GremlinServerExternalResource gremlinServer = new GremlinServerExternalResource(TestCommons::modernGraph);
 
     private List<Map<String, Object>> submitAndGet(String cypher) {
         return gremlinServer.cypherGremlinClient().submit(cypher).all();
@@ -72,7 +73,7 @@ public class UnionTest {
 
         assertThat(results)
             .extracting("name")
-            .containsExactly("stephen", "daniel", "marko", "marko", "josh", "peter");
+            .containsExactlyInAnyOrder("stephen", "daniel", "marko", "marko", "josh", "peter");
     }
 
     @Test

--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/UnwindTest.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/UnwindTest.java
@@ -22,10 +22,11 @@ import java.util.Map;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.opencypher.gremlin.rules.GremlinServerExternalResource;
+import org.opencypher.gremlin.test.TestCommons;
 
 public class UnwindTest {
     @ClassRule
-    public static final GremlinServerExternalResource gremlinServer = new GremlinServerExternalResource();
+    public static final GremlinServerExternalResource gremlinServer = new GremlinServerExternalResource(TestCommons::modernGraph);
 
     private List<Map<String, Object>> submitAndGet(String cypher) {
         return gremlinServer.cypherGremlinClient().submit(cypher).all();

--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/VariableLengthPathTest.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/VariableLengthPathTest.java
@@ -19,16 +19,6 @@ import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.assertj.core.util.Lists.newArrayList;
-import static org.opencypher.gremlin.test.TestCommons.JOSH;
-import static org.opencypher.gremlin.test.TestCommons.JOSH_CREATED_LOP;
-import static org.opencypher.gremlin.test.TestCommons.JOSH_CREATED_RIPPLE;
-import static org.opencypher.gremlin.test.TestCommons.LOP;
-import static org.opencypher.gremlin.test.TestCommons.MARKO;
-import static org.opencypher.gremlin.test.TestCommons.MARKO_CREATED_LOP;
-import static org.opencypher.gremlin.test.TestCommons.MARKO_KNOWS_JOSH;
-import static org.opencypher.gremlin.test.TestCommons.MARKO_KNOWS_VADAS;
-import static org.opencypher.gremlin.test.TestCommons.RIPPLE;
-import static org.opencypher.gremlin.test.TestCommons.VADAS;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -36,15 +26,24 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.opencypher.gremlin.rules.GremlinServerExternalResource;
+import org.opencypher.gremlin.test.TestCommons;
+import org.opencypher.gremlin.test.TestCommons.ModernGraph;
 import org.opencypher.gremlin.translation.ReturnProperties;
 
 public class VariableLengthPathTest {
-
     @ClassRule
     public static final GremlinServerExternalResource gremlinServer = new GremlinServerExternalResource();
+
+    public static ModernGraph g;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        g = TestCommons.modernGraph(gremlinServer.cypherGremlinClient());
+    }
 
     private List<Map<String, Object>> submitAndGet(String cypher) {
         return gremlinServer.cypherGremlinClient().submit(cypher).all();
@@ -215,12 +214,12 @@ public class VariableLengthPathTest {
         assertThat(results)
             .extracting("p")
             .containsExactlyInAnyOrder(
-                newArrayList(MARKO),
-                newArrayList(MARKO, MARKO_CREATED_LOP, LOP),
-                newArrayList(MARKO, MARKO_KNOWS_VADAS, VADAS),
-                newArrayList(MARKO, MARKO_KNOWS_JOSH, JOSH),
-                newArrayList(MARKO, MARKO_KNOWS_JOSH, JOSH, JOSH_CREATED_RIPPLE, RIPPLE),
-                newArrayList(MARKO, MARKO_KNOWS_JOSH, JOSH, JOSH_CREATED_LOP, LOP)
+                newArrayList(g.MARKO),
+                newArrayList(g.MARKO, g.MARKO_CREATED_LOP, g.LOP),
+                newArrayList(g.MARKO, g.MARKO_KNOWS_VADAS, g.VADAS),
+                newArrayList(g.MARKO, g.MARKO_KNOWS_JOSH, g.JOSH),
+                newArrayList(g.MARKO, g.MARKO_KNOWS_JOSH, g.JOSH, g.JOSH_CREATED_RIPPLE, g.RIPPLE),
+                newArrayList(g.MARKO, g.MARKO_KNOWS_JOSH, g.JOSH, g.JOSH_CREATED_LOP, g.LOP)
             );
     }
 }

--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/WhereTest.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/WhereTest.java
@@ -25,11 +25,12 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.opencypher.gremlin.groups.WithCustomPredicates;
 import org.opencypher.gremlin.rules.GremlinServerExternalResource;
+import org.opencypher.gremlin.test.TestCommons;
 
 public class WhereTest {
 
     @ClassRule
-    public static final GremlinServerExternalResource gremlinServer = new GremlinServerExternalResource();
+    public static final GremlinServerExternalResource gremlinServer = new GremlinServerExternalResource(TestCommons::modernGraph);
 
     private List<Map<String, Object>> submitAndGet(String cypher) {
         return gremlinServer.cypherGremlinClient().submit(cypher).all();

--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/WithTest.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/WithTest.java
@@ -24,11 +24,12 @@ import java.util.Map;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.opencypher.gremlin.rules.GremlinServerExternalResource;
+import org.opencypher.gremlin.test.TestCommons;
 
 public class WithTest {
 
     @ClassRule
-    public static final GremlinServerExternalResource gremlinServer = new GremlinServerExternalResource();
+    public static final GremlinServerExternalResource gremlinServer = new GremlinServerExternalResource(TestCommons::modernGraph);
 
     private List<Map<String, Object>> submitAndGet(String cypher) {
         return gremlinServer.cypherGremlinClient().submit(cypher).all();
@@ -141,7 +142,7 @@ public class WithTest {
 
         assertThat(results)
             .extracting("a.name")
-            .containsExactly("marko", "vadas", "josh", "peter");
+            .containsExactlyInAnyOrder("marko", "vadas", "josh", "peter");
     }
 
     @Test

--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/snippets/CypherGremlinServerClientSnippets.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/snippets/CypherGremlinServerClientSnippets.java
@@ -36,13 +36,14 @@ import org.junit.Test;
 import org.opencypher.gremlin.client.CypherGremlinClient;
 import org.opencypher.gremlin.client.CypherResultSet;
 import org.opencypher.gremlin.rules.GremlinServerExternalResource;
+import org.opencypher.gremlin.test.TestCommons;
 import org.opencypher.gremlin.translation.translator.Translator;
 import org.opencypher.gremlin.translation.translator.TranslatorFlavor;
 
 public class CypherGremlinServerClientSnippets {
 
     @ClassRule
-    public static final GremlinServerExternalResource gremlinServer = new GremlinServerExternalResource();
+    public static final GremlinServerExternalResource gremlinServer = new GremlinServerExternalResource(TestCommons::modernGraph);
 
     @Test
     public void gremlinStyle() throws Exception {

--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/suites/NativeTranslationSuite.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/suites/NativeTranslationSuite.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2018 "Neo4j, Inc." [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opencypher.gremlin.suites;
+
+import org.junit.experimental.categories.Categories;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.opencypher.gremlin.groups.WithCustomFunctions;
+import org.opencypher.gremlin.groups.WithCustomPredicates;
+import org.opencypher.gremlin.queries.CaseTest;
+import org.opencypher.gremlin.queries.CastTest;
+import org.opencypher.gremlin.queries.ComparisonTest;
+import org.opencypher.gremlin.queries.ComplexExamplesTest;
+import org.opencypher.gremlin.queries.ContainerIndexTest;
+import org.opencypher.gremlin.queries.CreateTest;
+import org.opencypher.gremlin.queries.DeleteTest;
+import org.opencypher.gremlin.queries.ExplainTest;
+import org.opencypher.gremlin.queries.ExpressionTest;
+import org.opencypher.gremlin.queries.FunctionTest;
+import org.opencypher.gremlin.queries.ListComprehensionTest;
+import org.opencypher.gremlin.queries.ListSliceTest;
+import org.opencypher.gremlin.queries.LiteralTest;
+import org.opencypher.gremlin.queries.MatchTest;
+import org.opencypher.gremlin.queries.MergeTest;
+import org.opencypher.gremlin.queries.NativeTraversalTest;
+import org.opencypher.gremlin.queries.NullTest;
+import org.opencypher.gremlin.queries.OptionalMatchTest;
+import org.opencypher.gremlin.queries.OrderByTest;
+import org.opencypher.gremlin.queries.ParameterTest;
+import org.opencypher.gremlin.queries.PercentileTest;
+import org.opencypher.gremlin.queries.ProcedureTest;
+import org.opencypher.gremlin.queries.RangeTest;
+import org.opencypher.gremlin.queries.ReturnTest;
+import org.opencypher.gremlin.queries.SetTest;
+import org.opencypher.gremlin.queries.UnionTest;
+import org.opencypher.gremlin.queries.UnwindTest;
+import org.opencypher.gremlin.queries.VariableLengthPathTest;
+import org.opencypher.gremlin.queries.WhereTest;
+import org.opencypher.gremlin.queries.WithTest;
+
+@RunWith(Categories.class)
+@Categories.ExcludeCategory({WithCustomFunctions.class, WithCustomPredicates.class})
+@Suite.SuiteClasses({CaseTest.class, NativeTraversalTest.class, CastTest.class, NullTest.class, ComparisonTest.class, OptionalMatchTest.class, ComplexExamplesTest.class, OrderByTest.class, ContainerIndexTest.class, ParameterTest.class, CreateTest.class, PercentileTest.class, DeleteTest.class, ProcedureTest.class, ExplainTest.class, RangeTest.class, ExpressionTest.class, ReturnTest.class, FunctionTest.class, SetTest.class, ListComprehensionTest.class, UnionTest.class, ListSliceTest.class, UnwindTest.class, LiteralTest.class, VariableLengthPathTest.class, MatchTest.class, WhereTest.class, MergeTest.class, WithTest.class})
+public class NativeTranslationSuite {
+}

--- a/testware/testware-common/src/main/java/org/opencypher/gremlin/server/EmbeddedGremlinServerFactory.java
+++ b/testware/testware-common/src/main/java/org/opencypher/gremlin/server/EmbeddedGremlinServerFactory.java
@@ -33,7 +33,7 @@ public final class EmbeddedGremlinServerFactory {
         return EmbeddedGremlinServer.builder()
             .port(port)
             .propertiesPath("graph","../testware-common/src/main/resources/tinkergraph-empty.properties")
-            .scriptPath("../testware-common/src/main/resources/generate-modern.groovy")
+            .scriptPath("../testware-common/src/main/resources/generate-empty.groovy")
             .serializer(GryoMessageSerializerV3d0.class, singletonList(TinkerIoRegistryV3d0.class))
             .build();
     }

--- a/testware/testware-common/src/main/java/org/opencypher/gremlin/test/TestCommons.java
+++ b/testware/testware-common/src/main/java/org/opencypher/gremlin/test/TestCommons.java
@@ -15,49 +15,72 @@
  */
 package org.opencypher.gremlin.test;
 
-import static org.opencypher.gremlin.translation.ReturnProperties.ID;
-import static org.opencypher.gremlin.translation.ReturnProperties.INV;
-import static org.opencypher.gremlin.translation.ReturnProperties.LABEL;
-import static org.opencypher.gremlin.translation.ReturnProperties.OUTV;
-import static org.opencypher.gremlin.translation.ReturnProperties.TYPE;
-
+import com.google.common.base.Charsets;
+import com.google.common.collect.Streams;
+import com.google.common.io.Resources;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
-import org.opencypher.gremlin.translation.groovy.GroovyGremlinSteps;
+import java.util.Objects;
+import org.assertj.core.groups.Tuple;
+import org.opencypher.gremlin.client.CypherGremlinClient;
 
 public class TestCommons {
-    public static Map<String, Object> MARKO = parameterMap(ID, 1, LABEL, "person", TYPE, "node", "age", 29L, "name", "marko");
-    public static Map<String, Object> VADAS = parameterMap(ID, 2, LABEL, "person", TYPE, "node", "age", 27L, "name", "vadas");
-    public static Map<String, Object> JOSH = parameterMap(ID, 4, LABEL, "person", TYPE, "node", "age", 32L, "name", "josh");
-    public static Map<String, Object> PETER = parameterMap(ID, 6, LABEL, "person", TYPE, "node", "age", 35L, "name", "peter");
+    public static String DELETE = "MATCH (n) DETACH DELETE n;";
 
-    public static Map<String, Object> LOP = parameterMap(ID, 3, LABEL, "software", TYPE, "node", "lang", "java", "name", "lop");
-    public static Map<String, Object> RIPPLE = parameterMap(ID, 5, LABEL, "software", TYPE, "node", "lang", "java", "name", "ripple");
+    public static class ModernGraph {
+        private ModernGraph() {
+        }
 
-    public static Map<String, Object> MARKO_KNOWS_VADAS = parameterMap(ID, 7, LABEL, "knows", TYPE, "relationship", "weight", 0.5, OUTV, MARKO.get(ID), INV, VADAS.get(ID));
-    public static Map<String, Object> MARKO_KNOWS_JOSH = parameterMap(ID, 8, LABEL, "knows", TYPE, "relationship", "weight", 1.0, OUTV, MARKO.get(ID), INV, JOSH.get(ID));
-    public static Map<String, Object> MARKO_CREATED_LOP = parameterMap(ID, 9, LABEL, "created", TYPE, "relationship", "weight", 0.4, OUTV, MARKO.get(ID), INV, LOP.get(ID));
+        public Map<String, Object> MARKO;
+        public Map<String, Object> VADAS;
+        public Map<String, Object> JOSH;
+        public Map<String, Object> PETER;
 
-    public static Map<String, Object> JOSH_CREATED_RIPPLE = parameterMap(ID, 10, LABEL, "created", TYPE, "relationship", "weight", 1.0, OUTV, JOSH.get(ID), INV, RIPPLE.get(ID));
-    public static Map<String, Object> JOSH_CREATED_LOP = parameterMap(ID, 11, LABEL, "created", TYPE, "relationship", "weight", 0.4, OUTV, JOSH.get(ID), INV, LOP.get(ID));
-    public static Map<String, Object> PETER_CREATED_LOP = parameterMap(ID, 12, LABEL, "created", TYPE, "relationship", "weight", 0.2, OUTV, PETER.get(ID), INV, LOP.get(ID));
+        public Map<String, Object> LOP;
+        public Map<String, Object> RIPPLE;
 
-    public static String DROP_ALL = new GroovyGremlinSteps().V().drop().current();
+        public Map<String, Object> MARKO_KNOWS_VADAS;
+        public Map<String, Object> MARKO_KNOWS_JOSH;
+        public Map<String, Object> MARKO_CREATED_LOP;
 
-    public static String CREATE_MODERN = new GroovyGremlinSteps()
-        .addV("person").property("name", "marko").property("age", 29).as("marko")
-        .addV("person").property("name", "vadas").property("age", 27).as("vadas")
-        .addV("software").property("name", "lop").property("lang", "java").as("lop")
-        .addV("person").property("name", "josh").property("age", 32).as("josh")
-        .addV("software").property("name", "ripple").property("lang", "java").as("ripple")
-        .addV("person").property("name", "peter").property("age", 35).as("peter")
-        .addE("knows").from("marko").to("vadas").property("weight", 0.5d)
-        .addE("knows").from("marko").to("josh").property("weight", 1.0d)
-        .addE("created").from("marko").to("lop").property("weight", 0.4d)
-        .addE("created").from("josh").to("ripple").property("weight", 1.0d)
-        .addE("created").from("josh").to("lop").property("weight", 0.4d)
-        .addE("created").from("peter").to("lop").property("weight", 0.2d)
-        .current();
+        public Map<String, Object> JOSH_CREATED_RIPPLE;
+        public Map<String, Object> JOSH_CREATED_LOP;
+        public Map<String, Object> PETER_CREATED_LOP;
+    }
+
+    @SuppressWarnings("unchecked")
+    public static ModernGraph modernGraph(CypherGremlinClient client) throws IOException {
+        String createModern = Resources.toString(Resources.getResource("modern.cyp"), Charsets.UTF_8).trim();
+
+        client.submit(DELETE).all();
+        Map<String, Object> r = client.submit(createModern).all().get(0);
+
+        ModernGraph g = new ModernGraph();
+
+        g.MARKO = (Map) r.get("marko");
+        g.VADAS = (Map) r.get("vadas");
+        g.JOSH = (Map) r.get("josh");
+        g.PETER = (Map) r.get("peter");
+        g.LOP = (Map) r.get("lop");
+        g.RIPPLE = (Map) r.get("ripple");
+        g.MARKO_KNOWS_VADAS = (Map) r.get("marko_knows_vadas");
+        g.MARKO_KNOWS_JOSH = (Map) r.get("marko_knows_josh");
+        g.MARKO_CREATED_LOP = (Map) r.get("marko_created_lop");
+        g.JOSH_CREATED_RIPPLE = (Map) r.get("josh_created_ripple");
+        g.JOSH_CREATED_LOP = (Map) r.get("josh_created_lop");
+        g.PETER_CREATED_LOP = (Map) r.get("peter_created_lop");
+
+        return g;
+    }
+
+    public static void snGraph(CypherGremlinClient client) throws IOException {
+        String createModern = Resources.toString(Resources.getResource("snMini.cyp"), Charsets.UTF_8).trim();
+        client.submit(DELETE).all();
+        client.submit(createModern).all();
+    }
 
     public static Map<String, Object> parameterMap(Object... parameters) {
         HashMap<String, Object> result = new HashMap<>();
@@ -65,5 +88,31 @@ public class TestCommons {
             result.put(String.valueOf(parameters[i]), parameters[i + 1]);
         }
         return result;
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> Comparator<T> ignoreOrderInCollections() {
+        return (t1, t2) -> {
+            if (t1 instanceof Tuple && t2 instanceof Tuple) {
+                return (int) Streams.zip(((Tuple) t1).toList().stream(), ((Tuple) t2).toList().stream(),
+                    (o1, o2) ->
+                        areEqualCollections(o1, o2) || Objects.equals(o1, o2))
+                    .filter(isEqual -> !isEqual)
+                    .count();
+            } else {
+                return (areEqualCollections(t1, t2) || Objects.equals(t1, t2)) ? 0 : 1;
+            }
+        };
+    }
+
+    @SuppressWarnings("unchecked")
+    private static boolean areEqualCollections(Object o1, Object o2) {
+        if (o1 != null && (o2 != null) &&
+            (o1 instanceof Collection) && (o2 instanceof Collection)) {
+            Collection list1 = Collection.class.cast(o1);
+            Collection list2 = Collection.class.cast(o2);
+            return list1.size() == list2.size() && list1.containsAll(list2);
+        }
+        return false;
     }
 }

--- a/testware/testware-common/src/main/resources/generate-empty.groovy
+++ b/testware/testware-common/src/main/resources/generate-empty.groovy
@@ -1,0 +1,2 @@
+def globals = [:]
+globals << [g: graph.traversal()]

--- a/testware/testware-common/src/main/resources/modern.cyp
+++ b/testware/testware-common/src/main/resources/modern.cyp
@@ -1,15 +1,14 @@
-MATCH (n)
-DETACH DELETE n;
-
-CREATE (marko:person {name: 'marko', age: 29})
-CREATE (vadas:person {name: 'vadas', age: 27})
-CREATE (josh:person {name: 'josh', age: 32})
-CREATE (peter:person {name: 'peter', age: 35})
-CREATE (lop:software {name: 'lop', lang: 'java'})
-CREATE (ripple:software {name: 'ripple', lang: 'java'})
-CREATE (marko)-[:knows {weight: 0.5}]->(vadas)
-CREATE (marko)-[:knows {weight: 1.0}]->(josh)
-CREATE (marko)-[:created {weight: 0.4}]->(lop)
-CREATE (peter)-[:created {weight: 0.2}]->(lop)
-CREATE (josh)-[:created {weight: 0.4}]->(lop)
-CREATE (josh)-[:created {weight: 1.0}]->(ripple);
+CREATE (marko:person {name: "marko", age: 29})
+CREATE (vadas:person {name: "vadas", age: 27})
+CREATE (lop:software { name: "lop", lang: "java"})
+CREATE (josh:person {name: "josh", age: 32})
+CREATE (ripple:software {name: "ripple", lang: "java"})
+CREATE (peter:person { name: "peter", age: 35}),
+(marko)-[marko_knows_vadas:knows {weight: 0.5}]->(vadas),
+(marko)-[marko_knows_josh:knows {weight: 1.0}]->(josh),
+(marko)-[marko_created_lop:created {weight: 0.4}]->(lop),
+(josh)-[josh_created_ripple:created {weight: 1.0}]->(ripple),
+(josh)-[josh_created_lop:created {weight: 0.4}]->(lop),
+(peter)-[peter_created_lop:created {weight: 0.2}]->(lop)
+RETURN marko, vadas, lop, josh, ripple, peter, marko_knows_vadas, marko_knows_josh, marko_created_lop,
+  josh_created_ripple, josh_created_lop, peter_created_lop;

--- a/testware/testware-common/src/main/resources/snMini.cyp
+++ b/testware/testware-common/src/main/resources/snMini.cyp
@@ -1,5 +1,3 @@
-MATCH (n) DETACH DELETE n;
-
 CREATE (id52171:City {cityId:52171, name:'Copenhagen'})
 CREATE (id53019:City {cityId:53019, name:'Oslo'})
 CREATE (id53109:City {cityId:53109, name:'Helsinki'})


### PR DESCRIPTION
- Test data refactoring
  + Externalized creation of "Modern Graph" to allow simple assertions on elements
  + Majority of tests don't need "Modern Graph", change default to empty graph
- Integration tests improvements
  + Avoid reserved names on different platforms (`label`, `property`)
  + Ignore result order where possible
- Create test suite for integration tests without extensions
- Speed up tests by starting Gremlin Server for test class instead of method

Signed-off-by: Dwitry dwitry@users.noreply.github.com