### PR TITLE
Rollback to deprecated `desc`/`incr` values.

### DIFF
--- a/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/CosmosDbFlavor.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/CosmosDbFlavor.scala
@@ -15,11 +15,10 @@
  */
 package org.opencypher.gremlin.translation.ir.rewrite
 
-import org.apache.tinkerpop.gremlin.process.traversal.{Order, Scope}
+import org.apache.tinkerpop.gremlin.process.traversal.Scope
 import org.apache.tinkerpop.gremlin.structure.VertexProperty.Cardinality
 import org.opencypher.gremlin.translation.ir.TraversalHelper._
 import org.opencypher.gremlin.translation.ir.model._
-import org.opencypher.gremlin.translation.traversal.DeprecatedOrderAccessor.{decr, incr}
 
 /**
   * This is a set of rewrites to adapt the translation to Cosmos DB.
@@ -31,8 +30,7 @@ object CosmosDbFlavor extends GremlinRewriter {
       rewriteRange(_),
       rewriteChoose(_),
       rewriteSkip(_),
-      stringIds(_),
-      tinkerPop334Workaround(_)
+      stringIds(_)
     ).foldLeft(steps) { (steps, rewriter) =>
       mapTraversals(rewriter)(steps)
     }
@@ -63,16 +61,6 @@ object CosmosDbFlavor extends GremlinRewriter {
             Inject(range: _*) :: rest
           case _ => throw new IllegalArgumentException("Ranges with expressions are not supported in Cosmos Db")
         }
-    })(steps)
-  }
-
-  private def tinkerPop334Workaround(steps: Seq[GremlinStep]): Seq[GremlinStep] = {
-    replace({
-      case By(traversal, Some(Order.asc)) :: rest =>
-        By(traversal, Some(incr)) :: rest
-      case By(traversal, Some(Order.desc)) :: rest =>
-        By(traversal, Some(decr)) :: rest
-
     })(steps)
   }
 

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/NeptuneFlavor.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/NeptuneFlavor.scala
@@ -15,13 +15,10 @@
  */
 package org.opencypher.gremlin.translation.ir.rewrite
 
-import org.apache.tinkerpop.gremlin.process
-import org.apache.tinkerpop.gremlin.process.traversal.Order
 import org.apache.tinkerpop.gremlin.structure.Column
 import org.opencypher.gremlin.translation.Tokens._
 import org.opencypher.gremlin.translation.ir.TraversalHelper._
 import org.opencypher.gremlin.translation.ir.model.{GremlinStep, _}
-import org.opencypher.gremlin.translation.traversal.DeprecatedOrderAccessor.{decr, incr}
 
 /**
   * This is a set of rewrites to adapt the translation to AWS Neptune.
@@ -42,8 +39,7 @@ object NeptuneFlavor extends GremlinRewriter {
   private def traversalRewriters(topLevelRewrites: Seq[GremlinStep]) = {
     Seq(
       barrierAfterCountWorkaround(_),
-      expandListProperties(_),
-      tinkerPop334Workaround(_)
+      expandListProperties(_)
     ).foldLeft(topLevelRewrites) { (steps, rewriter) =>
       mapTraversals(rewriter)(steps)
     }
@@ -55,16 +51,6 @@ object NeptuneFlavor extends GremlinRewriter {
         Count :: Barrier :: rest
       case CountS(scope) :: rest =>
         CountS(scope) :: Barrier :: rest
-    })(steps)
-  }
-
-  private def tinkerPop334Workaround(steps: Seq[GremlinStep]): Seq[GremlinStep] = {
-    replace({
-      case By(traversal, Some(Order.asc)) :: rest =>
-        By(traversal, Some(incr)) :: rest
-      case By(traversal, Some(Order.desc)) :: rest =>
-        By(traversal, Some(decr)) :: rest
-
     })(steps)
   }
 

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/walker/ProjectionWalker.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/walker/ProjectionWalker.scala
@@ -15,12 +15,12 @@
  */
 package org.opencypher.gremlin.translation.walker
 
-import org.apache.tinkerpop.gremlin.process.traversal.Order
 import org.apache.tinkerpop.gremlin.structure.Column
 import org.opencypher.gremlin.translation.GremlinSteps
 import org.opencypher.gremlin.translation.Tokens._
 import org.opencypher.gremlin.translation.context.WalkerContext
 import org.opencypher.gremlin.translation.exception.SyntaxException
+import org.opencypher.gremlin.translation.traversal.DeprecatedOrderAccessor
 import org.opencypher.gremlin.translation.walker.NodeUtils._
 import org.opencypher.gremlin.traversal.CustomFunction
 import org.opencypher.v9_0.ast._
@@ -388,9 +388,9 @@ private class ProjectionWalker[T, P](context: WalkerContext[T, P], g: GremlinSte
     for (sortItem <- sortItems) {
       val order = sortItem match {
         case _: AscSortItem =>
-          Order.asc
+          DeprecatedOrderAccessor.incr
         case _: DescSortItem =>
-          Order.desc
+          DeprecatedOrderAccessor.decr
       }
       val sortExpression = walkLocal(sortItem.expression, None)
       g.by(sortExpression, order)

--- a/translation/src/test/scala/org/opencypher/gremlin/translation/ir/rewrite/CosmosDbFlavorTest.scala
+++ b/translation/src/test/scala/org/opencypher/gremlin/translation/ir/rewrite/CosmosDbFlavorTest.scala
@@ -15,7 +15,7 @@
  */
 package org.opencypher.gremlin.translation.ir.rewrite
 
-import org.apache.tinkerpop.gremlin.process.traversal.{Order, Scope}
+import org.apache.tinkerpop.gremlin.process.traversal.Scope
 import org.apache.tinkerpop.gremlin.structure.VertexProperty.Cardinality
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.core.api.ThrowableAssert
@@ -100,16 +100,11 @@ class CosmosDbFlavorTest {
   }
 
   @Test
-  def tinkerPop334WorkaroundAsc(): Unit = {
+  def incrInOrder(): Unit = {
     assertThat(parse("MATCH (n) RETURN n ORDER BY n.name"))
       .withFlavor(flavor)
       .rewritingWith(NeptuneFlavor)
-      .removes(
-        __.by(
-          __.select("n")
-            .choose(P.neq(NULL), __.choose(__.values("name"), __.values("name"), __.constant("  cypher.null"))),
-          Order.asc))
-      .adds(
+      .contains(
         __.by(
           __.select("n")
             .choose(P.neq(NULL), __.choose(__.values("name"), __.values("name"), __.constant("  cypher.null"))),
@@ -117,16 +112,11 @@ class CosmosDbFlavorTest {
   }
 
   @Test
-  def tinkerPop334WorkaroundDesc(): Unit = {
+  def decrInOrder(): Unit = {
     assertThat(parse("MATCH (n) RETURN n ORDER BY n.name DESC"))
       .withFlavor(flavor)
       .rewritingWith(NeptuneFlavor)
-      .removes(
-        __.by(
-          __.select("n")
-            .choose(P.neq(NULL), __.choose(__.values("name"), __.values("name"), __.constant("  cypher.null"))),
-          Order.desc))
-      .adds(
+      .contains(
         __.by(
           __.select("n")
             .choose(P.neq(NULL), __.choose(__.values("name"), __.values("name"), __.constant("  cypher.null"))),

--- a/translation/src/test/scala/org/opencypher/gremlin/translation/ir/rewrite/NeptuneFlavorTest.scala
+++ b/translation/src/test/scala/org/opencypher/gremlin/translation/ir/rewrite/NeptuneFlavorTest.scala
@@ -15,7 +15,6 @@
  */
 package org.opencypher.gremlin.translation.ir.rewrite
 
-import org.apache.tinkerpop.gremlin.process.traversal.Order
 import org.junit.Test
 import org.opencypher.gremlin.translation.CypherAst.parse
 import org.opencypher.gremlin.translation.Tokens
@@ -119,16 +118,11 @@ class NeptuneFlavorTest {
   }
 
   @Test
-  def tinkerPop334WorkaroundAsc(): Unit = {
+  def incrInOrder(): Unit = {
     assertThat(parse("MATCH (n) RETURN n ORDER BY n.name"))
       .withFlavor(flavor)
       .rewritingWith(NeptuneFlavor)
-      .removes(
-        __.by(
-          __.select("n")
-            .choose(P.neq(NULL), __.choose(__.values("name"), __.values("name"), __.constant("  cypher.null"))),
-          Order.asc))
-      .adds(
+      .contains(
         __.by(
           __.select("n")
             .choose(P.neq(NULL), __.choose(__.values("name"), __.values("name"), __.constant("  cypher.null"))),
@@ -136,16 +130,11 @@ class NeptuneFlavorTest {
   }
 
   @Test
-  def tinkerPop334WorkaroundDesc(): Unit = {
+  def decrInOrder(): Unit = {
     assertThat(parse("MATCH (n) RETURN n ORDER BY n.name DESC"))
       .withFlavor(flavor)
       .rewritingWith(NeptuneFlavor)
-      .removes(
-        __.by(
-          __.select("n")
-            .choose(P.neq(NULL), __.choose(__.values("name"), __.values("name"), __.constant("  cypher.null"))),
-          Order.desc))
-      .adds(
+      .contains(
         __.by(
           __.select("n")
             .choose(P.neq(NULL), __.choose(__.values("name"), __.values("name"), __.constant("  cypher.null"))),


### PR DESCRIPTION
- Keep deprecated `desc`/`incr` while all backends (JanusGraph, CosmosDB, Neptune) have not upgraded to TinkerPop 3.3.4

Signed-off-by: Dwitry dwitry@users.noreply.github.com