### PR TITLE
Remove `g.inject(0)` -> `g.V().limit(0).inject(0)` workaround for Neptune

### DIFF
--- a/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/NeptuneFlavor.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/NeptuneFlavor.scala
@@ -26,7 +26,6 @@ import org.opencypher.gremlin.translation.ir.model.{GremlinStep, _}
 object NeptuneFlavor extends GremlinRewriter {
   override def apply(steps: Seq[GremlinStep]): Seq[GremlinStep] = {
     Seq(
-      injectWorkaround(_),
       limit0Workaround(_),
       multipleLabelsWorkaround(_),
       aggregateWithSameNameWorkaround(_),
@@ -79,15 +78,6 @@ object NeptuneFlavor extends GremlinRewriter {
       case By(expr, None) :: rest         => PropertyT(key, expr) +: expandSub(key, rest)
       case SelectC(Column.values) :: rest => rest
     })(bySteps)
-  }
-
-  private def injectWorkaround(steps: Seq[GremlinStep]): Seq[GremlinStep] = {
-    steps match {
-      case Inject(s) :: rest =>
-        Vertex :: Limit(0) :: Inject(s) :: rest
-      case _ =>
-        steps
-    }
   }
 
   private def limit0Workaround(steps: Seq[GremlinStep]): Seq[GremlinStep] = {

--- a/translation/src/test/scala/org/opencypher/gremlin/translation/ir/rewrite/NeptuneFlavorTest.scala
+++ b/translation/src/test/scala/org/opencypher/gremlin/translation/ir/rewrite/NeptuneFlavorTest.scala
@@ -29,14 +29,6 @@ class NeptuneFlavorTest {
   private val flavor = TranslatorFlavor.gremlinServer
 
   @Test
-  def injectWorkaroundTest(): Unit = {
-    assertThat(parse("RETURN 1"))
-      .withFlavor(flavor)
-      .rewritingWith(NeptuneFlavor)
-      .adds(__.V().limit(0))
-  }
-
-  @Test
   def limit0Workaround(): Unit = {
     assertThat(parse("CREATE ()"))
       .withFlavor(flavor)


### PR DESCRIPTION
- As it was fixed on target

Signed-off-by: Dwitry dwitry@users.noreply.github.com