### PR TITLE
Consider type in predicates:

### DIFF
--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/NullTest.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/NullTest.java
@@ -23,6 +23,8 @@ import java.util.Map;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.opencypher.gremlin.groups.SkipExtensions;
 import org.opencypher.gremlin.rules.GremlinServerExternalResource;
 
 public class NullTest {
@@ -62,6 +64,36 @@ public class NullTest {
 
         assertThat(results)
             .extracting("a")
+            .containsExactly((Object) null);
+    }
+
+    @Test
+    @Category(SkipExtensions.CustomPredicates.class)
+    public void predicateOnNull() {
+        submitAndGet("CREATE (a)");
+
+        List<Map<String, Object>> results = submitAndGet(
+            "MATCH (a)\n" +
+                "WHERE a.name CONTAINS 'b'\n" +
+                "RETURN count(a) as cnt"
+        );
+
+        assertThat(results)
+            .extracting("cnt")
+            .containsExactly(0L);
+    }
+
+    @Test
+    @Category(SkipExtensions.CustomPredicates.class)
+    public void nullOnIncompatibleTypes() {
+        submitAndGet(" CREATE ({val: 1})");
+
+        List<Map<String, Object>> results = submitAndGet(
+            "MATCH (n) RETURN 'a' STARTS WITH n.val as r"
+        );
+
+        assertThat(results)
+            .extracting("r")
             .containsExactly((Object) null);
     }
 }

--- a/tinkerpop/cypher-gremlin-extensions/src/main/java/org/opencypher/gremlin/traversal/CustomPredicate.java
+++ b/tinkerpop/cypher-gremlin-extensions/src/main/java/org/opencypher/gremlin/traversal/CustomPredicate.java
@@ -25,21 +25,21 @@ public enum CustomPredicate implements BiPredicate<Object, Object> {
     cypherStartsWith {
         @Override
         public boolean test(Object a, Object b) {
-            return a != null && b != null && a.toString().startsWith(b.toString());
+            return a.toString().startsWith(b.toString());
         }
     },
 
     cypherEndsWith {
         @Override
         public boolean test(Object a, Object b) {
-            return a != null && b != null && a.toString().endsWith(b.toString());
+            return a.toString().endsWith(b.toString());
         }
     },
 
     cypherContains {
         @Override
         public boolean test(Object a, Object b) {
-            return a != null && b != null && a.toString().contains(b.toString());
+            return a.toString().contains(b.toString());
         }
     },
 
@@ -54,6 +54,13 @@ public enum CustomPredicate implements BiPredicate<Object, Object> {
         @Override
         public boolean test(Object a, Object b) {
             return a instanceof Edge;
+        }
+    },
+
+    cypherIsString {
+        @Override
+        public boolean test(Object a, Object b) {
+            return a instanceof String;
         }
     };
 
@@ -75,5 +82,9 @@ public enum CustomPredicate implements BiPredicate<Object, Object> {
 
     public static P<Object> cypherIsRelationship() {
         return new P<>(CustomPredicate.cypherIsRelationship, null);
+    }
+
+    public static P<Object> cypherIsString() {
+        return new P<>(CustomPredicate.cypherIsString, null);
     }
 }

--- a/translation/src/main/java/org/opencypher/gremlin/translation/GremlinPredicates.java
+++ b/translation/src/main/java/org/opencypher/gremlin/translation/GremlinPredicates.java
@@ -55,4 +55,6 @@ public interface GremlinPredicates<P> {
     P isNode();
 
     P isRelationship();
+
+    P isString();
 }

--- a/translation/src/main/java/org/opencypher/gremlin/translation/bytecode/BytecodeGremlinPredicates.java
+++ b/translation/src/main/java/org/opencypher/gremlin/translation/bytecode/BytecodeGremlinPredicates.java
@@ -93,6 +93,11 @@ public class BytecodeGremlinPredicates implements GremlinPredicates<P> {
         return CustomPredicate.cypherIsRelationship();
     }
 
+    @Override
+    public P isString() {
+        return CustomPredicate.cypherIsString();
+    }
+
     private static Object[] inlineParameters(Object... values) {
         return Stream.of(values)
             .map(BytecodeGremlinPredicates::inlineParameter)

--- a/translation/src/main/java/org/opencypher/gremlin/translation/groovy/GroovyGremlinPredicates.java
+++ b/translation/src/main/java/org/opencypher/gremlin/translation/groovy/GroovyGremlinPredicates.java
@@ -92,4 +92,9 @@ public class GroovyGremlinPredicates implements GremlinPredicates<GroovyPredicat
     public GroovyPredicate isRelationship() {
         return new GroovyPredicate("cypherIsRelationship");
     }
+
+    @Override
+    public GroovyPredicate isString() {
+        return new GroovyPredicate("cypherIsString");
+    }
 }

--- a/translation/src/main/java/org/opencypher/gremlin/translation/traversal/TraversalGremlinPredicates.java
+++ b/translation/src/main/java/org/opencypher/gremlin/translation/traversal/TraversalGremlinPredicates.java
@@ -90,4 +90,9 @@ public class TraversalGremlinPredicates implements GremlinPredicates<P> {
     public P isRelationship() {
         return CustomPredicate.cypherIsRelationship();
     }
+
+    @Override
+    public P isString() {
+        return CustomPredicate.cypherIsString();
+    }
 }

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/ir/TranslationWriter.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/ir/TranslationWriter.scala
@@ -271,6 +271,7 @@ sealed class TranslationWriter[T, P] private (translator: Translator[T, P], para
       case Contains(value)        => p.contains(writeValue(value))
       case IsNode()               => p.isNode
       case IsRelationship()       => p.isRelationship
+      case IsString()             => p.isString
     }
   }
 

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/ir/builder/IRGremlinPredicates.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/ir/builder/IRGremlinPredicates.scala
@@ -46,4 +46,6 @@ class IRGremlinPredicates extends GremlinPredicates[GremlinPredicate] {
   override def isNode: GremlinPredicate = IsNode()
 
   override def isRelationship: GremlinPredicate = IsRelationship()
+
+  override def isString: GremlinPredicate = IsString()
 }

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/ir/model/GremlinPredicate.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/ir/model/GremlinPredicate.scala
@@ -30,4 +30,5 @@ case class StartsWith(value: Any) extends GremlinPredicate
 case class EndsWith(value: Any) extends GremlinPredicate
 case class Contains(value: Any) extends GremlinPredicate
 case class IsNode() extends GremlinPredicate
+case class IsString() extends GremlinPredicate
 case class IsRelationship() extends GremlinPredicate

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/RemoveUnusedAliases.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/RemoveUnusedAliases.scala
@@ -76,6 +76,7 @@ object RemoveUnusedAliases extends GremlinRewriter {
       case Contains(value)        => strings(value)
       case IsNode()               => Seq()
       case IsRelationship()       => Seq()
+      case IsString()             => Seq()
     }
   }
 }

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/walker/ProjectionWalker.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/walker/ProjectionWalker.scala
@@ -59,6 +59,8 @@ private class ProjectionWalker[T, P](context: WalkerContext[T, P], g: GremlinSte
   case object Expression extends ReturnFunctionType
   case object Pivot extends ReturnFunctionType
 
+  private val p = context.dsl.predicates()
+
   def walk(
       distinct: Boolean,
       items: Seq[ReturnItem],
@@ -212,7 +214,7 @@ private class ProjectionWalker[T, P](context: WalkerContext[T, P], g: GremlinSte
     expression match {
       case _: Add | _: ContainerIndex | _: CountStar | _: Divide | _: FunctionInvocation | _: ListLiteral | _: Literal |
           _: MapExpression | _: Modulo | _: Multiply | _: Null | _: Parameter | _: PatternComprehension | _: Pow |
-          _: Property | _: Subtract | _: Variable =>
+          _: Property | _: Subtract | _: Variable | _: StartsWith | _: Contains | _: EndsWith =>
         false
       case _ =>
         true
@@ -279,7 +281,6 @@ private class ProjectionWalker[T, P](context: WalkerContext[T, P], g: GremlinSte
       subTraversal: GremlinSteps[T, P],
       variable: String,
       expression: Expression): GremlinSteps[T, P] = {
-    val p = context.dsl.predicates()
 
     lazy val finalizeNode =
       __.valueMap(true)
@@ -334,8 +335,6 @@ private class ProjectionWalker[T, P](context: WalkerContext[T, P], g: GremlinSte
   }
 
   private def aggregation(alias: String, expression: Expression): (ReturnFunctionType, GremlinSteps[T, P]) = {
-    val p = context.dsl.predicates()
-
     expression match {
       case FunctionInvocation(_, FunctionName(fnName), distinct, args) =>
         if (args.flatMap(n => n +: n.subExpressions).exists {

--- a/translation/src/test/java/org/opencypher/gremlin/traversal/CustomPredicateTest.java
+++ b/translation/src/test/java/org/opencypher/gremlin/traversal/CustomPredicateTest.java
@@ -24,27 +24,18 @@ public class CustomPredicateTest {
     public void startsWith() throws Exception {
         assertThat(CustomPredicate.cypherStartsWith("a").test("abcd")).isTrue();
         assertThat(CustomPredicate.cypherStartsWith("x").test("abcd")).isFalse();
-        assertThat(CustomPredicate.cypherStartsWith("x").test(null)).isFalse();
-        assertThat(CustomPredicate.cypherStartsWith(null).test("abcd")).isFalse();
-        assertThat(CustomPredicate.cypherStartsWith(null).test(null)).isFalse();
     }
 
     @Test
     public void endsWith() throws Exception {
         assertThat(CustomPredicate.cypherEndsWith("d").test("abcd")).isTrue();
         assertThat(CustomPredicate.cypherEndsWith("x").test("abcd")).isFalse();
-        assertThat(CustomPredicate.cypherEndsWith("x").test(null)).isFalse();
-        assertThat(CustomPredicate.cypherEndsWith(null).test("abcd")).isFalse();
-        assertThat(CustomPredicate.cypherEndsWith(null).test(null)).isFalse();
     }
 
     @Test
     public void contains() throws Exception {
         assertThat(CustomPredicate.cypherContains("bc").test("abcd")).isTrue();
         assertThat(CustomPredicate.cypherContains("x").test("abcd")).isFalse();
-        assertThat(CustomPredicate.cypherContains("x").test(null)).isFalse();
-        assertThat(CustomPredicate.cypherContains(null).test("abcd")).isFalse();
-        assertThat(CustomPredicate.cypherContains(null).test(null)).isFalse();
     }
 
 }


### PR DESCRIPTION
- Additional predicate to check string type
- Return NULL in wrong predicate type
- Fix bug when string predicates were not recognized as `WHERE` conditions
- Merge changes from #191

TCK +3

Signed-off-by: Dwitry dwitry@users.noreply.github.com