### PR TITLE
Make `CypherOpProcessor` handle `scriptEvaluationTimeout`

### DIFF
--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/QueryTimeoutTest.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/QueryTimeoutTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2018-2019 "Neo4j, Inc." [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opencypher.gremlin.queries;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.tinkerpop.gremlin.driver.Client;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.opencypher.gremlin.rules.GremlinServerExternalResource;
+import org.opencypher.gremlin.server.EmbeddedGremlinServer;
+import org.opencypher.gremlin.translation.TranslationFacade;
+
+public class QueryTimeoutTest {
+
+    @ClassRule
+    public static final GremlinServerExternalResource gremlinServer = new GremlinServerExternalResource(
+        (c) -> {
+        },
+        () -> EmbeddedGremlinServer.builder()
+            .defaultParameters()
+            .scriptEvaluationTimeout(3)
+            .build()
+    );
+
+    private static final String SLOW_QUERY = "UNWIND range(0,10000) as a CREATE (n :test {test: a})";
+
+    private List<Map<String, Object>> submitAndGet(String cypher) {
+        return gremlinServer.cypherGremlinClient().submit(cypher).all();
+    }
+
+    @Test
+    public void testPluginGremlin() throws Exception {
+        Client client = gremlinServer.gremlinClient();
+
+        String gremlin = new TranslationFacade().toGremlinGroovy(SLOW_QUERY);
+
+        assertThatThrownBy(() -> client.submit(gremlin).all().get())
+            .hasMessageContaining("scriptEvaluationTimeout");
+    }
+
+    @Test
+    public void testPluginTimeout() throws Exception {
+        assertThatThrownBy(() -> submitAndGet(SLOW_QUERY))
+            .hasMessageContaining("scriptEvaluationTimeout");
+    }
+}

--- a/testware/testware-common/src/main/java/org/opencypher/gremlin/server/EmbeddedGremlinServer.java
+++ b/testware/testware-common/src/main/java/org/opencypher/gremlin/server/EmbeddedGremlinServer.java
@@ -91,6 +91,7 @@ public final class EmbeddedGremlinServer {
         private String scriptPath;
         private Map<String, Map<String, Object>> plugins = new HashMap<>();
         private List<Settings.ProcessorSettings> processorSettings = new ArrayList<>();
+        private long scriptEvaluationTimeout = 30000L;
         private Multimap<Class<? extends MessageSerializer>, Class<? extends IoRegistry>> serializers =
             HashMultimap.create();
 
@@ -130,6 +131,11 @@ public final class EmbeddedGremlinServer {
             return this;
         }
 
+        public Builder scriptEvaluationTimeout(long timeoutMs) {
+            this.scriptEvaluationTimeout = timeoutMs;
+            return this;
+        }
+
         public Builder processorSettings(Class<?> clazz, Map<String, Object> config) {
             Settings.ProcessorSettings settings = new Settings.ProcessorSettings();
             settings.className = clazz.getName();
@@ -145,6 +151,7 @@ public final class EmbeddedGremlinServer {
             Settings settings = new Settings();
             settings.port = getFreePort();
             settings.graphs = graphs;
+            settings.scriptEvaluationTimeout = scriptEvaluationTimeout;
 
             Settings.ScriptEngineSettings gremlinGroovy = settings.scriptEngines.get("gremlin-groovy");
             gremlinGroovy.imports.add(java.lang.Math.class.getName());


### PR DESCRIPTION
- to be consistent with `TraversalOpProcessor` and `AbstractEvalOpProcessor`
- part of #315

Signed-off-by: Dwitry dwitry@users.noreply.github.com