### PR TITLE
Workaround for CREATE without RETURN in Cosmos DB

### DIFF
--- a/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/SpecificsTest.java
+++ b/testware/integration-tests/src/test/java/org/opencypher/gremlin/queries/SpecificsTest.java
@@ -359,7 +359,6 @@ public class SpecificsTest {
     }
 
     @Test
-    @Category(SkipWithCosmosDB.NegativeRange.class)
     public void negativeRange() throws Exception {
 
         Client client = gremlinServer.gremlinClient();
@@ -372,7 +371,6 @@ public class SpecificsTest {
     }
 
     @Test
-    @Category(SkipWithCosmosDB.SignIsLost.class)
     public void signIsLost() throws Exception {
         Client client = gremlinServer.gremlinClient();
 

--- a/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/CosmosDbFlavor.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/ir/rewrite/CosmosDbFlavor.scala
@@ -36,7 +36,8 @@ object CosmosDbFlavor extends GremlinRewriter {
       replaceSelectValues(_),
       stringIds(_),
       neqOnDiff(_),
-      rewriteLoopsInVarLength(_)
+      rewriteLoopsInVarLength(_),
+      limit0Workaround(_)
     ).foldLeft(steps) { (steps, rewriter) =>
       mapTraversals(rewriter)(steps)
     }
@@ -126,6 +127,13 @@ object CosmosDbFlavor extends GremlinRewriter {
     replace({
       case Is(Neq(value)) :: rest =>
         Not(Is(Eq(value)) :: Nil) :: rest
+    })(steps)
+  }
+
+  private def limit0Workaround(steps: Seq[GremlinStep]): Seq[GremlinStep] = {
+    replace({
+      case Barrier :: Limit(0) :: rest =>
+        SelectK(Tokens.NONEXISTENT) :: rest
     })(steps)
   }
 

--- a/translation/src/test/scala/org/opencypher/gremlin/translation/ir/rewrite/CosmosDbFlavorTest.scala
+++ b/translation/src/test/scala/org/opencypher/gremlin/translation/ir/rewrite/CosmosDbFlavorTest.scala
@@ -21,6 +21,7 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.core.api.ThrowableAssert
 import org.junit.Test
 import org.opencypher.gremlin.translation.CypherAst.parse
+import org.opencypher.gremlin.translation.Tokens
 import org.opencypher.gremlin.translation.ir.builder.IRGremlinPredicates
 import org.opencypher.gremlin.translation.ir.helpers.CypherAstAssert.__
 import org.opencypher.gremlin.translation.ir.helpers.CypherAstAssertions.assertThat
@@ -149,5 +150,14 @@ class CosmosDbFlavorTest {
       .adds(
         __.property(Cardinality.single, "id", __.constant("1"))
       )
+  }
+
+  @Test
+  def limit0Workaround(): Unit = {
+    assertThat(parse("CREATE ()"))
+      .withFlavor(flavor)
+      .rewritingWith(NeptuneFlavor)
+      .removes(__.limit(0))
+      .adds(__.select(Tokens.NONEXISTENT))
   }
 }


### PR DESCRIPTION
- Workaround to address recent change in Cosmos DB, where traversal ending at `.barrier().limit(0)` was not evaluated
- Updated tests according to recent changes in Cosmos DB
- fixes #314

Signed-off-by: Dwitry dwitry@users.noreply.github.com