### PR TITLE
OPTIONAL match should generate an `optional()` call not  `choose()`

### DIFF
--- a/translation/src/main/scala/org/opencypher/gremlin/translation/walker/MatchWalker.scala
+++ b/translation/src/main/scala/org/opencypher/gremlin/translation/walker/MatchWalker.scala
@@ -62,7 +62,7 @@ private class MatchWalker[T, P](context: WalkerContext[T, P], g: GremlinSteps[T,
     val subG = g.start()
     MatchWalker.walkPatternParts(context, subG, patternParts, whereOption)
 
-    g.choose(subG, subG, nullG)
+    g.optional(subG)
   }
 
   def walkPatternParts(patternParts: Seq[PatternPart], whereOption: Option[Where]): Unit = {


### PR DESCRIPTION
Hello 👋🏻 ,

Right now, the query :

```cypher
MATCH (doc:DOCUMENT)
OPTIONAL MATCH (ner:NER {subtype: 'LOCATION'})
RETURN distinct(ID(doc))
```

Is currently translated to 

```java
g.V().as('doc').hasLabel('DOCUMENT').choose(__.V().hasLabel('NER').has('subtype', eq('LOCATION')), __.V().hasLabel('NER').has('subtype', eq('LOCATION')), __.constant('  cypher.null')).select('doc').project('(ID(doc))').by(__.choose(neq('  cypher.null'), __.id())).dedup()
```

but it should be translated to 

```java
g.V().hasLabel('DOCUMENT').as('doc')
    .optional(__.V().hasLabel('NER').has('subtype', 'LOCATION'))
    .select('doc')
    .id()
    .dedup()

```


I literally CANNOT get the project to build and use it correctly in ArcadeDB, issue with missing symbols.

Some tests are failing, which is expected considering some of they searches 'choose' inside it and others are failing like  : 




(**Some** of the failing tests)

**matchAndReverseOptionalMatch**

```txt
java.lang.AssertionError: [Extracted: a1.name, r.name, b2.name] 
Actual and expected should have same size but actual size was:
  <0>
while expected size was:
  <1>
Actual was:
  <[]>
Expected was:
  <[("A", "T", null)]>

```


```scala
    @Test
    @Category(SkipWithCosmosDB.Truncate4096.class)
    public void matchAndReverseOptionalMatch() throws Exception {
        submitAndGet("CREATE (:A {name: 'A'})-[:T {name: 'T'}]->(:B {name: 'B'})");
        List<Map<String, Object>> results = submitAndGet(
            "MATCH (a1)-[r]->() " +
                "WITH r, a1 " +
                "OPTIONAL MATCH (a1)<-[r]-(b2) " +
                "RETURN a1.name, r.name, b2.name"
        );

        assertThat(results)
            .extracting("a1.name", "r.name", "b2.name")
            .containsExactly(tuple("A", "T", null));
    }

```


**optionalMatchOnEmptyGraph**

```txt

java.lang.AssertionError: [Extracted: n] 
Actual and expected should have same size but actual size was:
  <0>
while expected size was:
  <1>
Actual was:
  <[]>
Expected was:
  <[null]>
```


```scala

    @Test
    public void optionalMatchOnEmptyGraph() throws Exception {
        List<Map<String, Object>> results = submitAndGet(
            "OPTIONAL MATCH (n) " +
                "RETURN n"
        );

        assertThat(results)
            .extracting("n")
            .containsExactly((Object) null);
    }

```


**optionalStartEndNode**

```txt
java.lang.AssertionError: [Extracted: a, b] 
Expecting:
  <[]>
to contain exactly in any order:
  <[(null, null)]>
but could not find the following elements:
  <[(null, null)]>

```


```scala
    @Test
    public void optionalStartEndNode() {
        List<Map<String, Object>> results = submitAndGet(
            "OPTIONAL MATCH ()-[r:notExisting]-()\n" +
                "RETURN startNode(r) as a, endNode(r) as b");

        assertThat(results)
            .extracting("a", "b")
            .containsExactlyInAnyOrder(tuple(null, null));
    }

```




This feature being broken sounds QUITE CRITICAL.

Opened issues on arcadedb using gremlin+cypher 

https://github.com/ArcadeData/arcadedb/issues/1929

https://github.com/ArcadeData/arcadedb/issues/1948
